### PR TITLE
Wire mediaUploadFn for WordPress media library uploads

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -24,6 +24,12 @@ import {
 import type { ToolGroup, DiffData, FetchFn } from '@extrachill/chat';
 import type { ReactNode } from 'react';
 
+/**
+ * Upload function provided by the consumer.
+ * Matches @extrachill/chat MediaUploadFn (available in v0.9.0+).
+ */
+type MediaUploadFn = ( file: File ) => Promise<{ url: string; media_id?: number }>;
+
 interface AgentChatProps {
 	agentId: number;
 	basePath: string;
@@ -64,6 +70,28 @@ const agentFetch: FetchFn = ( options ) =>
 		data: options.data,
 		headers: options.headers,
 	} );
+
+/**
+ * Upload a file to the WordPress Media Library.
+ *
+ * Uses the standard wp/v2/media endpoint via @wordpress/api-fetch,
+ * which handles nonce auth automatically.
+ */
+const wpMediaUpload: MediaUploadFn = async ( file: File ) => {
+	const formData = new FormData();
+	formData.append( 'file', file );
+
+	const media = await apiFetch( {
+		path: '/wp/v2/media',
+		method: 'POST',
+		body: formData,
+	} ) as { id: number; source_url: string };
+
+	return {
+		url: media.source_url,
+		media_id: media.id,
+	};
+};
 
 function renderDiffCard( group: ToolGroup ): ReactNode {
 	const diff = parseDiffFromToolResult( group );
@@ -157,6 +185,7 @@ export default function AgentChat( {
 						createElement( 'p', null, agentDescription )
 					),
 				loadingMessages,
+				mediaUploadFn: wpMediaUpload,
 				processingLabel: ( turnCount: number ) =>
 					__( `Working… (turn ${ turnCount })`, 'data-machine-frontend-chat' ),
 				} )


### PR DESCRIPTION
## Summary

Wires the `mediaUploadFn` prop from @extrachill/chat into the frontend chat widget, enabling file uploads through the WordPress Media Library.

## What changed

**`AgentChat.tsx`:**
- Added `wpMediaUpload` function that uploads files to `/wp/v2/media` via `@wordpress/api-fetch`
- Passes it as `mediaUploadFn` to `<Chat>`, which enables the attach button and routes files through WP Media Library
- `MediaUploadFn` type defined locally until `@extrachill/chat` v0.9.0 is published to npm

## How it works

```
User attaches image in chat
       │
  ChatInput captures File object
       │
  useChat calls wpMediaUpload(file)
       │
  POST /wp/v2/media (FormData with nonce auth)
       │
  Returns { url: source_url, media_id: id }
       │
  SendAttachment sent to chat endpoint with real url + media_id
       │
  Data Machine resolves file → builds multimodal content → AI sees image
```

## Dependencies

- @extrachill/chat v0.9.0 (Extra-Chill/chat#12, merged and tagged but pending npm publish)
- Currently builds against v0.8.0 with the type defined locally

## Related

- Extra-Chill/chat#11 — original issue
- Extra-Chill/chat#12 — `mediaUploadFn` implementation in chat package