### PR TITLE
feat: add FAB unread badge, rename Roadie→ChatWidget, escape key, safe-area

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -12,7 +12,7 @@
  * @package DataMachineFrontendChat
  * @since 0.3.0
  */
-import { createElement, useState, useCallback, useMemo } from '@wordpress/element';
+import { createElement, useState, useCallback, useMemo, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import {
@@ -114,9 +114,21 @@ export default function AgentChat( {
 	loadingMessages = true,
 }: AgentChatProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
+	const [ unreadCount, setUnreadCount ] = useState( 0 );
 	const metadata = useClientContextMetadata();
 	const open = useCallback( () => setIsOpen( true ), [] );
 	const close = useCallback( () => setIsOpen( false ), [] );
+
+	// Close drawer on Escape key.
+	useEffect( () => {
+		function handleKeyDown( e: KeyboardEvent ) {
+			if ( e.key === 'Escape' && isOpen ) {
+				setIsOpen( false );
+			}
+		}
+		document.addEventListener( 'keydown', handleKeyDown );
+		return () => document.removeEventListener( 'keydown', handleKeyDown );
+	}, [ isOpen ] );
 
 	const toolRenderers = useMemo(
 		() => ( {
@@ -130,17 +142,22 @@ export default function AgentChat( {
 	return createElement(
 		'div',
 		{ className: 'datamachine-chat' },
-		! isOpen &&
-			createElement(
-				'button',
-				{
-					type: 'button',
-					className: 'datamachine-chat__fab',
-					onClick: open,
-					'aria-label': __( `Open ${ agentName } chat`, 'data-machine-frontend-chat' ),
-				},
-				agentName
-			),
+		createElement(
+			'button',
+			{
+				type: 'button',
+				className: `datamachine-chat__fab${ isOpen ? ' is-hidden' : '' }`,
+				onClick: open,
+				'aria-label': __( `Open ${ agentName } chat`, 'data-machine-frontend-chat' ),
+			},
+			agentName,
+			unreadCount > 0 &&
+				createElement(
+					'span',
+					{ className: 'datamachine-chat__fab-badge' },
+					unreadCount > 99 ? '99+' : unreadCount
+				)
+		),
 		createElement(
 			'div',
 			{
@@ -178,6 +195,8 @@ export default function AgentChat( {
 					toolRenderers,
 					placeholder: __( `Ask ${ agentName } anything…`, 'data-machine-frontend-chat' ),
 					metadata,
+					isVisible: isOpen,
+					onUnreadChange: setUnreadCount,
 					emptyState: createElement(
 						'div',
 						{ className: 'datamachine-chat__empty' },

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -28,7 +28,7 @@
 .datamachine-chat__fab {
 	position: fixed;
 	z-index: 9999;
-	bottom: var(--spacing-lg, 24px);
+	bottom: calc(var(--spacing-lg, 24px) + env(safe-area-inset-bottom, 0px));
 	right: var(--spacing-lg, 24px);
 	display: flex;
 	align-items: center;
@@ -44,17 +44,48 @@
 	font-weight: 700;
 	cursor: pointer;
 	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
-	transition: transform 0.15s, box-shadow 0.15s;
+	transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease, visibility 0.2s ease;
 	pointer-events: auto;
+	opacity: 1;
+	visibility: visible;
 }
 
 .datamachine-chat__fab:hover {
-	transform: translateY(-2px);
+	transform: translateY(-2px) scale(1.02);
 	box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
 }
 
 .datamachine-chat__fab:active {
-	transform: translateY(0);
+	transform: translateY(0) scale(0.98);
+}
+
+/* Hide FAB when drawer is open (CSS-based, keeps it in DOM). */
+.datamachine-chat__fab.is-hidden {
+	opacity: 0;
+	visibility: hidden;
+	transform: scale(0.8);
+	pointer-events: none;
+}
+
+/* ── FAB Unread Badge ────────────────────────────────── */
+
+.datamachine-chat__fab-badge {
+	position: absolute;
+	top: -4px;
+	right: -4px;
+	min-width: 20px;
+	height: 20px;
+	padding: 0 6px;
+	border-radius: 10px;
+	background: var(--ec-chat-tool-error, #ef4444);
+	color: #fff;
+	font-size: 11px;
+	font-weight: 700;
+	line-height: 20px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	pointer-events: none;
 }
 
 /* ── Admin bar offset ────────────────────────────────── */
@@ -165,8 +196,7 @@
 	--ec-chat-send-text: var(--background-color, #f8fafc);
 	--ec-chat-tool-bg: var(--background-color, #f8fafc);
 	--ec-chat-tool-border: var(--border-color, #e2e8f0);
-	--ec-chat-session-active-bg: var(--background-color, #f8fafc);
-	--ec-chat-session-hover-bg: var(--background-color, #f8fafc);
+	--ec-chat-session-hover-bg: var(--border-color, #e2e8f0);
 	--ec-chat-font-family: var(--font-family-body, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
 	--ec-chat-border-radius: 0;
 


### PR DESCRIPTION
## Summary

Full-stack unread messages integration for the frontend chat widget, plus cleanup items from the audit.

- Rename `RoadieChat` → `ChatWidget`, `roadie.css` → `widget.css` (internal naming cleanup)
- Add unread badge to FAB (red pill counter, capped at 99+)
- Pass `isVisible={isOpen}` and `onUnreadChange={setUnreadCount}` to `<Chat>`
- Keep FAB in DOM always (CSS visibility toggle instead of conditional rendering, enables smooth transitions)
- Add fade/scale transition to FAB on drawer open/close
- Add Escape key handler to close drawer
- Add `env(safe-area-inset-bottom)` to FAB bottom position for notched iPhones
- Remove dead `--ec-chat-session-active-bg` remapping (removed upstream)
- Give `--ec-chat-session-hover-bg` a distinct fallback (`--border-color` instead of `--background-color`)
- Sync `package.json` version with plugin header (0.4.5)

Closes #4

**Depends on:** Extra-Chill/data-machine#997, Extra-Chill/chat#16

```
data-machine #997 (last_read_at + unread_count backend)
    ↓
chat #16 (onUnreadChange, isVisible, markAsRead)
    ↓
data-machine-frontend-chat #4 (this — FAB badge + cleanup)
```