### PR TITLE
chore(deps): bump @extrachill/chat ^0.8.0 -> ^0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "data-machine-frontend-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "^0.8.0"
+				"@extrachill/chat": "^0.10.1"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2656,9 +2656,9 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.8.0.tgz",
-			"integrity": "sha512-TX1g6dfOUtuIq+H0Zaw+N8iZ19y6t2RAglvLYo9TjFitrcGLoO3EZOMe4cD3KXHSMlUcqxrifGlP00rLrWi03A==",
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.10.1.tgz",
+			"integrity": "sha512-eQ9L7LQi+0WKBvNV5SONDyql14M/OL9necuAtq5NdCz2qd9JhIz5WeCqwmzz9JTzGj1FgvniusKjSOXi2RGuWQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "^0.8.0"
+		"@extrachill/chat": "^0.10.1"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",


### PR DESCRIPTION
## Summary

Caret ranges on 0.x.y versions pin the minor (per npm semver, `^0.8.0` means `>=0.8.0 <0.9.0`). So the source was locked to 0.8.x with no upgrade path except a manual bump.

`AgentChat.tsx` already references v0.9.0+ \`MediaUploadFn\` — the comment block literally says *"Matches @extrachill/chat MediaUploadFn (available in v0.9.0+)"* — so bumping unlocks the intended API plus:

- **v0.9.0** — `mediaUploadFn` callback prop wired through
- **v0.10.0** — unread message tracking + dark mode + a11y fixes

No breaking changes in that range per the upstream changelog ([link](https://github.com/Extra-Chill/chat/blob/main/CHANGELOG.md)).

## What changed

```diff
- "@extrachill/chat": "^0.8.0"
+ "@extrachill/chat": "^0.10.1"
```

## Verification

- `npm run typecheck` (`tsc --noEmit`) — clean
- `npm run build` — webpack compiled successfully

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Ran an ecosystem-wide audit of `@extrachill/chat` pins across DM repos after a related fix in `data-machine`. Verified no breaking changes in the 0.8 → 0.10.1 range via upstream CHANGELOG.md, confirmed source already references v0.9+ API. Ran typecheck and build for verification.