### PR TITLE
Fix broken Accept/Reject: call /actions/resolve, not /diff/resolve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "data-machine-frontend-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "^0.8.0"
+				"@extrachill/chat": "^0.10.1"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2656,9 +2656,9 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.8.0.tgz",
-			"integrity": "sha512-TX1g6dfOUtuIq+H0Zaw+N8iZ19y6t2RAglvLYo9TjFitrcGLoO3EZOMe4cD3KXHSMlUcqxrifGlP00rLrWi03A==",
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.10.1.tgz",
+			"integrity": "sha512-eQ9L7LQi+0WKBvNV5SONDyql14M/OL9necuAtq5NdCz2qd9JhIz5WeCqwmzz9JTzGj1FgvniusKjSOXi2RGuWQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "^0.8.0"
+		"@extrachill/chat": "^0.10.1"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -5,9 +5,10 @@
  * The Chat component stays mounted when the drawer closes so session
  * state, messages, and scroll position survive open/close cycles.
  *
- * When AI uses content-editing tools (edit_post_blocks, replace_post_blocks)
- * with preview mode, the tool result is rendered as a DiffCard with
- * Accept/Reject buttons instead of raw JSON.
+ * When AI uses a pending-action tool (edit_post_blocks, replace_post_blocks,
+ * insert_content) with preview mode, the tool result is rendered as a
+ * DiffCard with Accept/Reject buttons instead of raw JSON. Accept/Reject
+ * hit Data Machine's unified /actions/resolve endpoint.
  *
  * @package DataMachineFrontendChat
  * @since 0.3.0
@@ -21,14 +22,8 @@ import {
 	useClientContextMetadata,
 	parseCanonicalDiffFromToolGroup,
 } from '@extrachill/chat';
-import type { ToolGroup, DiffData, FetchFn } from '@extrachill/chat';
+import type { ToolGroup, DiffData, FetchFn, MediaUploadFn } from '@extrachill/chat';
 import type { ReactNode } from 'react';
-
-/**
- * Upload function provided by the consumer.
- * Matches @extrachill/chat MediaUploadFn (available in v0.9.0+).
- */
-type MediaUploadFn = ( file: File ) => Promise<{ url: string; media_id?: number }>;
 
 interface AgentChatProps {
 	agentId: number;
@@ -45,21 +40,33 @@ interface AgentChatProps {
 /**
  * Parse a tool result into DiffData for DiffCard rendering.
  *
- * Returns null if the tool result is not a preview diff (e.g. the tool
- * was called without preview=true, or the result is malformed).
+ * Returns null if the tool result is not a preview action (e.g. the
+ * tool was called without preview=true, or the result is malformed).
  */
 function parseDiffFromToolResult( group: ToolGroup ): DiffData | null {
 	return parseCanonicalDiffFromToolGroup( group );
 }
 
-function resolveDiff( diffId: string, decision: 'accepted' | 'rejected' ): void {
+/**
+ * Resolve a pending action by id.
+ *
+ * Data Machine unified its preview primitive on a generic pending-action
+ * model in PR #1171 (editor #5): the old /datamachine/v1/diff/resolve
+ * endpoint and `diff_id` parameter were removed in favour of
+ * /datamachine/v1/actions/resolve with `action_id`. The unified endpoint
+ * handles every preview-capable tool kind, not just content diffs, so
+ * this callback works uniformly for edit_post_blocks, replace_post_blocks,
+ * insert_content, and any future kind a plugin registers on the
+ * `datamachine_pending_action_handlers` filter.
+ */
+function resolvePendingAction( actionId: string, decision: 'accepted' | 'rejected' ): void {
 	apiFetch( {
-		path: '/datamachine/v1/diff/resolve',
+		path: '/datamachine/v1/actions/resolve',
 		method: 'POST',
-		data: { diff_id: diffId, decision },
+		data: { action_id: actionId, decision },
 	} ).catch( ( err: unknown ) => {
 		// eslint-disable-next-line no-console
-		console.error( 'AgentChat: failed to resolve diff', diffId, err );
+		console.error( 'AgentChat: failed to resolve pending action', actionId, err );
 	} );
 }
 
@@ -101,8 +108,8 @@ function renderDiffCard( group: ToolGroup ): ReactNode {
 
 	return createElement( DiffCard, {
 		diff,
-		onAccept: ( id: string ) => resolveDiff( id, 'accepted' ),
-		onReject: ( id: string ) => resolveDiff( id, 'rejected' ),
+		onAccept: ( actionId: string ) => resolvePendingAction( actionId, 'accepted' ),
+		onReject: ( actionId: string ) => resolvePendingAction( actionId, 'rejected' ),
 	} );
 }
 


### PR DESCRIPTION
## Summary

The Accept/Reject buttons on diff preview cards have been 404'ing on every click since Data Machine unified its preview primitive on a generic pending-action model:

- [DM PR #1171](https://github.com/Extra-Chill/data-machine/pull/1171) + [data-machine-editor PR #5](https://github.com/Extra-Chill/data-machine-editor/pull/5) (merged 2026-04-23):
  - `/datamachine/v1/diff/resolve` → **removed**
  - `/datamachine/v1/actions/resolve` → new home for every preview-capable tool kind (not just content diffs)
  - `diff_id` → `action_id` on the request payload
  - `ResolveDiffAbility` / `PendingDiffStore` → deleted in favour of `ResolvePendingActionAbility` + `PendingActionStore`

## Fix

- Rename `resolveDiff()` → `resolvePendingAction()`.
- Call `/datamachine/v1/actions/resolve` with `{ action_id, decision }`.
- Rename callback parameters `diffId` → `actionId` end-to-end.
- Drop the local `MediaUploadFn` type redeclaration; import it from `@extrachill/chat` where it's already exported (v0.9.0+).
- Bump `@extrachill/chat` dep from `^0.8.0` → `^0.10.1`. The installed 0.8.0 was missing `isVisible`, `onUnreadChange`, `MediaUploadFn`, and the current `useClientContextMetadata` shape — all referenced by this file. `npm ci` in a fresh checkout type-failed until this bump.

## Round-trip note (follow-up required)

`@extrachill/chat@0.10.1` only reads `diff.diffId` / `diff_id` from tool payloads. DM's `CanonicalDiffPreview::build()` now emits `actionId`. So the id delivered to the resolve endpoint will still be empty until the chat package also learns the `actionId` vocabulary — companion PR filed: https://github.com/Extra-Chill/chat/pull/21.

The endpoint rename here is still correct in isolation — it gets the frontend off the deleted route — and full end-to-end functionality unblocks as soon as that chat bump lands. A follow-up will pin `@extrachill/chat` to whatever version ships the `actionId` field (e.g. `^0.11.0`).

## Validation

- `npm ci` + `npm run build` — succeeds, no warnings.
- `npm run typecheck` — clean.
- Visual check of the built bundle confirms `actions/resolve` + `action_id` are present and `diff/resolve` + `diff_id` are gone.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Traced the unified preview primitive through DM + editor PRs, drafted the endpoint rename, the upstream chat PR, and validated the two pieces against each other. Chris flagged the audit target.