### PR TITLE
chore(deps): bump @extrachill/chat ^0.10.1 -> ^0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "data-machine-frontend-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "^0.10.1"
+				"@extrachill/chat": "^0.11.0"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2656,9 +2656,9 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.10.1.tgz",
-			"integrity": "sha512-eQ9L7LQi+0WKBvNV5SONDyql14M/OL9necuAtq5NdCz2qd9JhIz5WeCqwmzz9JTzGj1FgvniusKjSOXi2RGuWQ==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.11.0.tgz",
+			"integrity": "sha512-wOskWB9SucQKGWmMfC98Fvyeg7cIBmYoeZtrh06RBKZTtSJP0JL5TYnANYsyf578jOX7y9KzLt3i/LCHbu9Cjg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "^0.10.1"
+		"@extrachill/chat": "^0.11.0"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",


### PR DESCRIPTION
## Summary

This is the dep bump that actually makes #7 work end-to-end.

## Context

PR #7 renamed the `resolveDiff()` helper to `resolvePendingAction()` and updated it to POST `/datamachine/v1/actions/resolve` with `{ action_id, decision }` — the DM unified pending-action endpoint. But the chat package at `^0.10.1` only exposed `diffId` / `diff_id` from `parseCanonicalDiff`, never `actionId`. So the DiffCard's `onAccept(id)` / `onReject(id)` callbacks were delivering an **empty string** to `resolvePendingAction`, which the `/actions/resolve` endpoint then rejected with a validation error.

The full fix required `@extrachill/chat@0.11.0`, which landed:

- **[chat #21](https://github.com/Extra-Chill/chat/pull/21)** — `parseCanonicalDiff` now reads `actionId` / `action_id` (prioritized) with fallback to `diffId` / `diff_id`. Populates both fields on the returned shape so consumers reading either keep working.
- **[chat #23](https://github.com/Extra-Chill/chat/pull/23)** — also recognizes `container.preview` nesting, which is DM's envelope shape from `PendingActionHelper::stage()`.

With 0.11 in place, DiffCard's accept/reject callbacks deliver the real action id and the round-trip works.

## Other 0.11 additions

- **[chat #22](https://github.com/Extra-Chill/chat/pull/22)** — forwards `onToolCalls` + `sessionContext` from `<Chat>` to `useChat`. Not used here, but free.

## Validation

- `npm install @extrachill/chat@^0.11.0` — resolves to 0.11.0.
- `npm run typecheck` — clean.
- `npm run build` — clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Traced the empty-action_id bug through the consumer → package → DM server chain, drafted the upstream chat fixes to close the gap, cut chat 0.11 (Chris ran the publish), then rolled the bump across all three consumers. This PR completes the end-to-end accept/reject flow kicked off by #7.