### PR TITLE
Add frontend agent switcher

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -66,6 +66,49 @@ function frontend_agent_chat_user_can_see( ?array $agent ): bool {
 }
 
 /**
+ * List accessible Agents API agents for the current user.
+ *
+ * @return array<int,array{agent_slug:string,agent_name:string,agent_description:string,meta:array}>
+ */
+function frontend_agent_chat_list_accessible_agents(): array {
+	$minimum_role = class_exists( 'WP_Agent_Access_Grant' ) ? WP_Agent_Access_Grant::ROLE_VIEWER : 'viewer';
+	$result       = frontend_agent_chat_execute_ability( 'agents/list-accessible-agents', array( 'minimum_role' => $minimum_role ) );
+	$agents       = is_array( $result ) && is_array( $result['agents'] ?? null ) ? $result['agents'] : array();
+	$normalized   = array();
+
+	foreach ( $agents as $agent ) {
+		$agent = frontend_agent_chat_normalize_agent( is_array( $agent ) ? $agent : array() );
+		if ( ! $agent ) {
+			continue;
+		}
+
+		$normalized[] = $agent;
+	}
+
+	return $normalized;
+}
+
+/**
+ * Normalize an Agents API descriptor for frontend chat use.
+ *
+ * @param array $agent Raw agent descriptor.
+ * @return array|null Normalized descriptor or null.
+ */
+function frontend_agent_chat_normalize_agent( array $agent ): ?array {
+	$slug = sanitize_title( (string) ( $agent['slug'] ?? $agent['agent_slug'] ?? '' ) );
+	if ( '' === $slug ) {
+		return null;
+	}
+
+	return array(
+		'agent_slug'        => $slug,
+		'agent_name'        => (string) ( $agent['label'] ?? $agent['agent_name'] ?? $slug ),
+		'agent_description' => (string) ( $agent['description'] ?? $agent['agent_description'] ?? '' ),
+		'meta'              => is_array( $agent['meta'] ?? null ) ? $agent['meta'] : array(),
+	);
+}
+
+/**
  * Check agent access through Agents API.
  *
  * @param string $agent_slug   Registered agent slug/id.
@@ -110,21 +153,12 @@ function frontend_agent_chat_resolve_agent( string $slug ): ?array {
 		return null;
 	}
 
-	$minimum_role = class_exists( 'WP_Agent_Access_Grant' ) ? WP_Agent_Access_Grant::ROLE_VIEWER : 'viewer';
-	$result       = frontend_agent_chat_execute_ability( 'agents/list-accessible-agents', array( 'minimum_role' => $minimum_role ) );
-	$agents       = is_array( $result ) && is_array( $result['agents'] ?? null ) ? $result['agents'] : array();
-
-	foreach ( $agents as $agent ) {
-		if ( ! is_array( $agent ) || sanitize_title( (string) ( $agent['slug'] ?? '' ) ) !== $slug ) {
+	foreach ( frontend_agent_chat_list_accessible_agents() as $agent ) {
+		if ( $agent['agent_slug'] !== $slug ) {
 			continue;
 		}
 
-		return array(
-			'agent_slug'        => (string) ( $agent['slug'] ?? '' ),
-			'agent_name'        => (string) ( $agent['label'] ?? $agent['slug'] ?? '' ),
-			'agent_description' => (string) ( $agent['description'] ?? '' ),
-			'meta'              => is_array( $agent['meta'] ?? null ) ? $agent['meta'] : array(),
-		);
+		return $agent;
 	}
 
 	return null;

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -22,18 +22,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 function frontend_agent_chat_enqueue() {
 	$config = frontend_agent_chat_get_config();
 
-	if ( empty( $config['enabled'] ) || empty( $config['agent_slug'] ) ) {
+	if ( empty( $config['enabled'] ) ) {
 		return;
 	}
 
-	$agent = frontend_agent_chat_resolve_agent( $config['agent_slug'] );
-	if ( ! $agent ) {
+	$agents = frontend_agent_chat_list_accessible_agents();
+	if ( empty( $agents ) ) {
 		return;
 	}
 
-	if ( ! frontend_agent_chat_user_can_see( $agent ) ) {
-		return;
+	$agent = null;
+	if ( ! empty( $config['agent_slug'] ) ) {
+		$agent = frontend_agent_chat_resolve_agent( (string) $config['agent_slug'] );
 	}
+	$agent = $agent ?: $agents[0];
 
 	$build_dir = FRONTEND_AGENT_CHAT_PLUGIN_DIR . 'build/';
 	$build_url = FRONTEND_AGENT_CHAT_PLUGIN_URL . 'build/';
@@ -65,6 +67,7 @@ function frontend_agent_chat_enqueue() {
 	$js_config = array(
 		'agentSlug'        => (string) ( $agent['agent_slug'] ?? $config['agent_slug'] ),
 		'basePath'         => '/frontend-agent-chat/v1/chat',
+		'agentsPath'       => '/frontend-agent-chat/v1/agents',
 		'agentName'        => (string) ( $agent['agent_name'] ?? $agent['label'] ?? $config['agent_slug'] ),
 		'agentDescription' => (string) ( $agent['agent_description'] ?? $agent['description'] ?? $config['description'] ),
 	);

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -17,6 +17,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 function frontend_agent_chat_register_rest_routes(): void {
 	register_rest_route(
 		'frontend-agent-chat/v1',
+		'/agents',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'frontend_agent_chat_rest_list_agents',
+			'permission_callback' => 'frontend_agent_chat_rest_can_chat',
+		)
+	);
+
+	register_rest_route(
+		'frontend-agent-chat/v1',
 		'/chat',
 		array(
 			'methods'             => WP_REST_Server::CREATABLE,
@@ -89,18 +99,77 @@ add_action( 'rest_api_init', 'frontend_agent_chat_register_rest_routes' );
  *
  * @return bool
  */
-function frontend_agent_chat_rest_can_chat(): bool {
+function frontend_agent_chat_rest_can_chat( ?WP_REST_Request $request = null ): bool {
 	$config = frontend_agent_chat_get_config();
-	if ( empty( $config['enabled'] ) || empty( $config['agent_slug'] ) ) {
+	if ( empty( $config['enabled'] ) ) {
 		return false;
 	}
+	if ( $request && '/frontend-agent-chat/v1/agents' === $request->get_route() ) {
+		return ! empty( frontend_agent_chat_list_accessible_agents() );
+	}
 
-	$agent = frontend_agent_chat_resolve_agent( (string) $config['agent_slug'] );
+	$agent_slug = $request ? frontend_agent_chat_rest_get_agent_slug( $request, (string) ( $config['agent_slug'] ?? '' ) ) : (string) ( $config['agent_slug'] ?? '' );
+	if ( '' === $agent_slug ) {
+		return ! empty( frontend_agent_chat_list_accessible_agents() );
+	}
+
+	$agent = frontend_agent_chat_resolve_agent( $agent_slug );
 	if ( ! $agent ) {
 		return false;
 	}
 
 	return frontend_agent_chat_user_can_see( $agent );
+}
+
+/**
+ * List accessible agents for the selector.
+ *
+ * @return WP_REST_Response
+ */
+function frontend_agent_chat_rest_list_agents(): WP_REST_Response {
+	$agents = frontend_agent_chat_list_accessible_agents();
+	return rest_ensure_response(
+		array(
+			'success' => true,
+			'data'    => array(
+				'agents' => array_map( 'frontend_agent_chat_rest_agent_summary', $agents ),
+			),
+		)
+	);
+}
+
+/**
+ * Build a REST-safe agent summary.
+ *
+ * @param array $agent Normalized agent descriptor.
+ * @return array
+ */
+function frontend_agent_chat_rest_agent_summary( array $agent ): array {
+	return array(
+		'slug'        => (string) ( $agent['agent_slug'] ?? '' ),
+		'name'        => (string) ( $agent['agent_name'] ?? $agent['agent_slug'] ?? '' ),
+		'description' => (string) ( $agent['agent_description'] ?? '' ),
+		'meta'        => is_array( $agent['meta'] ?? null ) ? $agent['meta'] : array(),
+	);
+}
+
+/**
+ * Resolve the requested agent slug, falling back to a configured default.
+ *
+ * @param WP_REST_Request $request      REST request.
+ * @param string          $default_slug Optional configured default.
+ * @return string
+ */
+function frontend_agent_chat_rest_get_agent_slug( WP_REST_Request $request, string $default_slug = '' ): string {
+	$agent = $request->get_param( 'agent' );
+	if ( null === $agent || '' === (string) $agent ) {
+		$agent = $request->get_param( 'agent_slug' );
+	}
+	if ( null === $agent || '' === (string) $agent ) {
+		$agent = $default_slug;
+	}
+
+	return sanitize_title( (string) $agent );
 }
 
 /**
@@ -116,9 +185,11 @@ function frontend_agent_chat_rest_send_message( WP_REST_Request $request ) {
 	}
 
 	$config      = frontend_agent_chat_get_config();
-	$agent_param = $request->get_param( 'agent' );
-	$agent_slug  = sanitize_title( (string) ( '' !== (string) $agent_param ? $agent_param : $config['agent_slug'] ) );
+	$agent_slug  = frontend_agent_chat_rest_get_agent_slug( $request, (string) ( $config['agent_slug'] ?? '' ) );
 	$session_id  = sanitize_text_field( (string) $request->get_param( 'session_id' ) );
+	if ( '' === $agent_slug ) {
+		return new WP_Error( 'frontend_agent_chat_missing_agent', __( 'Agent is required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+	}
 
 	if ( '' === $session_id ) {
 		$created = frontend_agent_chat_execute_ability(
@@ -247,11 +318,16 @@ function frontend_agent_chat_rest_list_sessions( WP_REST_Request $request ) {
 	$config      = frontend_agent_chat_get_config();
 	$limit_param = $request->get_param( 'limit' );
 	$limit       = max( 1, min( 100, (int) ( null !== $limit_param ? $limit_param : 20 ) ) );
+	$agent_slug  = frontend_agent_chat_rest_get_agent_slug( $request, (string) ( $config['agent_slug'] ?? '' ) );
+	if ( '' === $agent_slug ) {
+		return new WP_Error( 'frontend_agent_chat_missing_agent', __( 'Agent is required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+	}
+
 	$result      = frontend_agent_chat_execute_ability(
 		'agents/list-conversation-sessions',
 		array(
 			'limit'   => $limit,
-			'agent'   => sanitize_title( (string) $config['agent_slug'] ),
+			'agent'   => $agent_slug,
 			'context' => 'frontend-agent-chat',
 		)
 	);

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -24,7 +24,7 @@ import {
 	parseCanonicalDiffFromToolGroup,
 } from '@extrachill/chat';
 import type { ToolGroup, DiffData, FetchFn, MediaUploadFn } from '@extrachill/chat';
-import type { ReactNode } from 'react';
+import type { ChangeEvent, ReactNode } from 'react';
 
 /**
  * WordPress dependencies
@@ -34,14 +34,28 @@ import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
 interface AgentChatProps {
-	agentSlug: string;
+	agentSlug?: string;
 	basePath: string;
+	agentsPath: string;
 	agentName: string;
 	agentDescription: string;
 	loadingMessages?: boolean | {
 		mode?: 'default' | 'extend' | 'override';
 		messages?: string[];
 		interval?: number;
+	};
+}
+
+interface AgentSummary {
+	slug: string;
+	name: string;
+	description: string;
+}
+
+interface AgentsResponse {
+	success?: boolean;
+	data?: {
+		agents?: AgentSummary[];
 	};
 }
 
@@ -80,14 +94,21 @@ function resolvePendingAction( actionId: string, decision: 'accepted' | 'rejecte
 }
 
 function createAgentFetch( agentSlug: string ): FetchFn {
-	return ( options ) => apiFetch( {
-		path: options.path,
-		method: options.method,
-		data: options.method === 'POST'
-			? { ...( options.data ?? {} ), agent: agentSlug }
-			: options.data,
-		headers: options.headers,
-	} );
+	return ( options ) => {
+		const method = options.method ?? 'GET';
+		const separator = options.path.includes( '?' ) ? '&' : '?';
+
+		return apiFetch( {
+			path: method === 'GET' || method === 'DELETE'
+				? `${ options.path }${ separator }agent=${ encodeURIComponent( agentSlug ) }`
+				: options.path,
+			method: options.method,
+			data: method === 'POST'
+				? { ...( options.data ?? {} ), agent: agentSlug }
+				: options.data,
+			headers: options.headers,
+		} );
+	};
 }
 
 /**
@@ -131,16 +152,60 @@ function renderDiffCard( group: ToolGroup ): ReactNode {
 export default function AgentChat( {
 	agentSlug,
 	basePath,
+	agentsPath,
 	agentName,
 	agentDescription,
 	loadingMessages = true,
 }: AgentChatProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ unreadCount, setUnreadCount ] = useState( 0 );
+	const [ agents, setAgents ] = useState< AgentSummary[] >( () => agentSlug ? [ {
+		slug: agentSlug,
+		name: agentName,
+		description: agentDescription,
+	} ] : [] );
+	const [ selectedAgentSlug, setSelectedAgentSlug ] = useState( agentSlug ?? '' );
 	const metadata = useClientContextMetadata();
-	const agentFetch = useMemo( () => createAgentFetch( agentSlug ), [ agentSlug ] );
+	const selectedAgent = useMemo(
+		() => agents.find( ( agent ) => agent.slug === selectedAgentSlug ) ?? agents[0],
+		[ agents, selectedAgentSlug ]
+	);
+	const activeAgentSlug = selectedAgent?.slug ?? '';
+	const activeAgentName = selectedAgent?.name ?? agentName;
+	const activeAgentDescription = selectedAgent?.description ?? agentDescription;
+	const agentFetch = useMemo( () => createAgentFetch( activeAgentSlug ), [ activeAgentSlug ] );
 	const open = useCallback( () => setIsOpen( true ), [] );
 	const close = useCallback( () => setIsOpen( false ), [] );
+	const switchAgent = useCallback( ( event: ChangeEvent< HTMLSelectElement > ) => {
+		setSelectedAgentSlug( event.target.value );
+	}, [] );
+
+	useEffect( () => {
+		apiFetch( { path: agentsPath } )
+			.then( ( response ) => {
+				const nextAgents = ( response as AgentsResponse ).data?.agents ?? [];
+				if ( nextAgents.length === 0 ) {
+					return;
+				}
+
+				setAgents( nextAgents );
+				setSelectedAgentSlug( ( current ) => {
+					if ( current && nextAgents.some( ( agent ) => agent.slug === current ) ) {
+						return current;
+					}
+
+					return nextAgents[0].slug;
+				} );
+			} )
+			.catch( ( err: unknown ) => {
+				// eslint-disable-next-line no-console
+				console.error( 'AgentChat: failed to load accessible agents', err );
+			} );
+	}, [ agentsPath ] );
+
+	useEffect( () => {
+		setUnreadCount( 0 );
+	}, [ activeAgentSlug ] );
 
 	// Close drawer on Escape key.
 	useEffect( () => {
@@ -174,10 +239,10 @@ export default function AgentChat( {
 				'aria-label': sprintf(
 					/* translators: %s: agent name. */
 					__( 'Open %s chat', 'frontend-agent-chat' ),
-					agentName
+					activeAgentName
 				),
 			},
-			agentName,
+			activeAgentName,
 			unreadCount > 0 &&
 				createElement(
 					'span',
@@ -195,9 +260,26 @@ export default function AgentChat( {
 				'div',
 				{ className: 'frontend-agent-chat__header' },
 				createElement(
-					'span',
-					{ className: 'frontend-agent-chat__title' },
-					agentName
+					'div',
+					{ className: 'frontend-agent-chat__agent' },
+					agents.length > 1 ? createElement(
+						'select',
+						{
+							className: 'frontend-agent-chat__agent-select',
+							value: activeAgentSlug,
+							onChange: switchAgent,
+							'aria-label': __( 'Select chat agent', 'frontend-agent-chat' ),
+						},
+						agents.map( ( agent ) => createElement(
+							'option',
+							{ key: agent.slug, value: agent.slug },
+							agent.name
+						) )
+					) : createElement(
+						'span',
+						{ className: 'frontend-agent-chat__title' },
+						activeAgentName
+					)
 				),
 				createElement(
 					'button',
@@ -213,7 +295,8 @@ export default function AgentChat( {
 			createElement(
 				'div',
 				{ className: 'frontend-agent-chat__body' },
-				createElement( Chat, {
+				activeAgentSlug && createElement( Chat, {
+					key: activeAgentSlug,
 					basePath,
 					fetchFn: agentFetch,
 					showTools: true,
@@ -222,7 +305,7 @@ export default function AgentChat( {
 					placeholder: sprintf(
 						/* translators: %s: agent name. */
 						__( 'Ask %s anything…', 'frontend-agent-chat' ),
-						agentName
+						activeAgentName
 					),
 					metadata,
 					isVisible: isOpen,
@@ -230,8 +313,8 @@ export default function AgentChat( {
 					emptyState: createElement(
 						'div',
 						{ className: 'frontend-agent-chat__empty' },
-						createElement( 'h3', null, agentName ),
-						createElement( 'p', null, agentDescription )
+						createElement( 'h3', null, activeAgentName ),
+						createElement( 'p', null, activeAgentDescription )
 					),
 					loadingMessages,
 					mediaUploadFn: wpMediaUpload,

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -114,16 +114,46 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	gap: var(--frontend-agent-chat-spacing-sm, 12px);
 	padding: var(--frontend-agent-chat-spacing-xs, 8px) var(--frontend-agent-chat-spacing-md, 16px);
 	border-bottom: 1px solid var(--frontend-agent-chat-border-color, #e2e8f0);
 	flex-shrink: 0;
 }
 
+.frontend-agent-chat__agent {
+	min-width: 0;
+	flex: 1;
+}
+
 .frontend-agent-chat__title {
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 	font-family: var(--frontend-agent-chat-header-font-family, var(--frontend-agent-chat-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif));
 	font-size: var(--frontend-agent-chat-header-font-size, 18px);
 	font-weight: 700;
 	color: var(--frontend-agent-chat-text-primary, #1e293b);
+}
+
+.frontend-agent-chat__agent-select {
+	width: 100%;
+	max-width: 260px;
+	min-height: 36px;
+	padding: 0 32px 0 12px;
+	border: 1px solid var(--frontend-agent-chat-border-color, #e2e8f0);
+	border-radius: 18px;
+	background: var(--frontend-agent-chat-bg-muted, #f8fafc);
+	color: var(--frontend-agent-chat-text-primary, #1e293b);
+	font-family: var(--frontend-agent-chat-header-font-family, var(--frontend-agent-chat-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif));
+	font-size: var(--frontend-agent-chat-header-font-size, 15px);
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.frontend-agent-chat__agent-select:focus {
+	outline: 2px solid var(--frontend-agent-chat-accent, #2563eb);
+	outline-offset: 2px;
 }
 
 .frontend-agent-chat__close {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,9 @@ import AgentChat from './AgentChat';
 declare global {
 	interface Window {
 		frontendAgentChatConfig?: {
-			agentSlug: string;
+			agentSlug?: string;
 			basePath: string;
+			agentsPath: string;
 			agentName: string;
 			agentDescription: string;
 			loadingMessages?: boolean | {
@@ -60,7 +61,7 @@ function init(): void {
 	}
 
 	const config = window.frontendAgentChatConfig;
-	if ( ! config?.agentSlug ) {
+	if ( ! config?.basePath || ! config?.agentsPath ) {
 		return;
 	}
 
@@ -70,6 +71,7 @@ function init(): void {
 		createElement( AgentChat, {
 			agentSlug: config.agentSlug,
 			basePath: config.basePath,
+			agentsPath: config.agentsPath,
 			agentName: config.agentName,
 			agentDescription: config.agentDescription,
 			loadingMessages: config.loadingMessages ?? true,


### PR DESCRIPTION
## Summary
- Adds an accessible-agents REST endpoint backed by Agents API.
- Lets the frontend widget select among accessible agents instead of requiring a single configured slug.
- Scopes chat/session requests to the selected agent and remounts chat state on switch.

## Testing
- `npm run typecheck`
- `npm run build`
- `php -l inc/config.php && php -l inc/enqueue.php && php -l inc/rest.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the agent-switching UI, REST adapter changes, and verification flow; Chris remains responsible for review and merge.