### PR TITLE
Persist selected frontend agent

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -89,6 +89,20 @@ function frontend_agent_chat_list_accessible_agents(): array {
 }
 
 /**
+ * Read the current user's active Data Machine agent preference when available.
+ *
+ * @return string Active agent slug or empty string.
+ */
+function frontend_agent_chat_get_active_agent_slug(): string {
+	$result = frontend_agent_chat_execute_ability( 'datamachine/get-active-agent', array() );
+	if ( is_wp_error( $result ) || ! is_array( $result ) || empty( $result['success'] ) ) {
+		return '';
+	}
+
+	return sanitize_title( (string) ( $result['agent_slug'] ?? '' ) );
+}
+
+/**
  * Normalize an Agents API descriptor for frontend chat use.
  *
  * @param array $agent Raw agent descriptor.

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -27,6 +27,23 @@ function frontend_agent_chat_register_rest_routes(): void {
 
 	register_rest_route(
 		'frontend-agent-chat/v1',
+		'/agents/active',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'frontend_agent_chat_rest_get_active_agent',
+				'permission_callback' => 'frontend_agent_chat_rest_can_chat',
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'frontend_agent_chat_rest_set_active_agent',
+				'permission_callback' => 'frontend_agent_chat_rest_can_chat',
+			),
+		)
+	);
+
+	register_rest_route(
+		'frontend-agent-chat/v1',
 		'/chat',
 		array(
 			'methods'             => WP_REST_Server::CREATABLE,
@@ -127,12 +144,63 @@ function frontend_agent_chat_rest_can_chat( ?WP_REST_Request $request = null ): 
  * @return WP_REST_Response
  */
 function frontend_agent_chat_rest_list_agents(): WP_REST_Response {
-	$agents = frontend_agent_chat_list_accessible_agents();
+	$agents      = frontend_agent_chat_list_accessible_agents();
+	$active_slug = frontend_agent_chat_get_active_agent_slug();
 	return rest_ensure_response(
 		array(
 			'success' => true,
 			'data'    => array(
-				'agents' => array_map( 'frontend_agent_chat_rest_agent_summary', $agents ),
+				'active_agent_slug' => $active_slug,
+				'agents'            => array_map( 'frontend_agent_chat_rest_agent_summary', $agents ),
+			),
+		)
+	);
+}
+
+/**
+ * Get the current user's active Data Machine agent preference.
+ *
+ * @return WP_REST_Response
+ */
+function frontend_agent_chat_rest_get_active_agent(): WP_REST_Response {
+	return rest_ensure_response(
+		array(
+			'success' => true,
+			'data'    => array(
+				'agent_slug' => frontend_agent_chat_get_active_agent_slug(),
+			),
+		)
+	);
+}
+
+/**
+ * Persist the current user's active Data Machine agent preference.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function frontend_agent_chat_rest_set_active_agent( WP_REST_Request $request ) {
+	$agent_slug = sanitize_title( (string) $request->get_param( 'agent' ) );
+	if ( '' === $agent_slug ) {
+		$agent_slug = sanitize_title( (string) $request->get_param( 'agent_slug' ) );
+	}
+	if ( '' === $agent_slug ) {
+		return new WP_Error( 'frontend_agent_chat_missing_agent', __( 'Agent is required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+	}
+
+	$result = frontend_agent_chat_execute_ability( 'datamachine/set-active-agent', array( 'agent' => $agent_slug ) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+	if ( empty( $result['success'] ) ) {
+		return new WP_Error( 'frontend_agent_chat_active_agent_failed', (string) ( $result['error'] ?? __( 'Failed to set active agent.', 'frontend-agent-chat' ) ), array( 'status' => 400 ) );
+	}
+
+	return rest_ensure_response(
+		array(
+			'success' => true,
+			'data'    => array(
+				'agent_slug' => sanitize_title( (string) ( $result['agent_slug'] ?? $agent_slug ) ),
 			),
 		)
 	);

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -55,6 +55,7 @@ interface AgentSummary {
 interface AgentsResponse {
 	success?: boolean;
 	data?: {
+		active_agent_slug?: string;
 		agents?: AgentSummary[];
 	};
 }
@@ -109,6 +110,17 @@ function createAgentFetch( agentSlug: string ): FetchFn {
 			headers: options.headers,
 		} );
 	};
+}
+
+function persistActiveAgent( agentSlug: string ): void {
+	apiFetch( {
+		path: '/frontend-agent-chat/v1/agents/active',
+		method: 'POST',
+		data: { agent: agentSlug },
+	} ).catch( ( err: unknown ) => {
+		// eslint-disable-next-line no-console
+		console.error( 'AgentChat: failed to persist active agent', agentSlug, err );
+	} );
 }
 
 /**
@@ -167,23 +179,27 @@ export default function AgentChat( {
 	const [ selectedAgentSlug, setSelectedAgentSlug ] = useState( agentSlug ?? '' );
 	const metadata = useClientContextMetadata();
 	const selectedAgent = useMemo(
-		() => agents.find( ( agent ) => agent.slug === selectedAgentSlug ) ?? agents[0],
+		() => agents.find( ( agent ) => agent.slug === selectedAgentSlug ),
 		[ agents, selectedAgentSlug ]
 	);
 	const activeAgentSlug = selectedAgent?.slug ?? '';
 	const activeAgentName = selectedAgent?.name ?? agentName;
 	const activeAgentDescription = selectedAgent?.description ?? agentDescription;
+	const fabLabel = __( 'Consult Intelligence', 'frontend-agent-chat' );
 	const agentFetch = useMemo( () => createAgentFetch( activeAgentSlug ), [ activeAgentSlug ] );
 	const open = useCallback( () => setIsOpen( true ), [] );
 	const close = useCallback( () => setIsOpen( false ), [] );
 	const switchAgent = useCallback( ( event: ChangeEvent< HTMLSelectElement > ) => {
-		setSelectedAgentSlug( event.target.value );
+		const nextAgentSlug = event.target.value;
+		setSelectedAgentSlug( nextAgentSlug );
+		persistActiveAgent( nextAgentSlug );
 	}, [] );
 
 	useEffect( () => {
 		apiFetch( { path: agentsPath } )
 			.then( ( response ) => {
-				const nextAgents = ( response as AgentsResponse ).data?.agents ?? [];
+				const data = ( response as AgentsResponse ).data ?? {};
+				const nextAgents = data.agents ?? [];
 				if ( nextAgents.length === 0 ) {
 					return;
 				}
@@ -192,6 +208,11 @@ export default function AgentChat( {
 				setSelectedAgentSlug( ( current ) => {
 					if ( current && nextAgents.some( ( agent ) => agent.slug === current ) ) {
 						return current;
+					}
+
+					const activeAgentSlug = data.active_agent_slug ?? '';
+					if ( activeAgentSlug && nextAgents.some( ( agent ) => agent.slug === activeAgentSlug ) ) {
+						return activeAgentSlug;
 					}
 
 					return nextAgents[0].slug;
@@ -242,7 +263,7 @@ export default function AgentChat( {
 					activeAgentName
 				),
 			},
-			activeAgentName,
+			fabLabel,
 			unreadCount > 0 &&
 				createElement(
 					'span',


### PR DESCRIPTION
## Summary
- Read the Data Machine active-agent preference when loading the frontend chat agent selector.
- Persist selector changes through a small REST proxy to `datamachine/set-active-agent`.
- Keep the neutral FAB label while the selected agent continues to drive chat routing.

## Testing
- `npm run typecheck`
- `npm run build`
- `php -l inc/rest.php && php -l inc/config.php`

## Depends on
- Extra-Chill/data-machine#2003 or the Data Machine active-agent preference abilities being available.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the REST proxy and frontend selector persistence wiring; Chris reviewed direction and requested the implementation.