### PR TITLE
Update frontend chat FAB label

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -185,7 +185,7 @@ export default function AgentChat( {
 	const activeAgentSlug = selectedAgent?.slug ?? '';
 	const activeAgentName = selectedAgent?.name ?? agentName;
 	const activeAgentDescription = selectedAgent?.description ?? agentDescription;
-	const fabLabel = __( 'Consult Intelligence', 'frontend-agent-chat' );
+	const fabLabel = __( '🧠 Brain Chat', 'frontend-agent-chat' );
 	const agentFetch = useMemo( () => createAgentFetch( activeAgentSlug ), [ activeAgentSlug ] );
 	const open = useCallback( () => setIsOpen( true ), [] );
 	const close = useCallback( () => setIsOpen( false ), [] );


### PR DESCRIPTION
## Summary
- Change the floating chat button label from `Consult Intelligence` to `🧠 Brain Chat`.

## Testing
- `npm run typecheck`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Applied the requested one-line label update and ran verification.