### PR TITLE
Fix brain chat launcher spacing

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,7 +1,7 @@
 {
   "id": "frontend-agent-chat",
   "changelog_target": "docs/CHANGELOG.md",
-  "remote_path": "wp-content/plugins/frontend-agent-chat",
+  "remote_path": "../wp-content/plugins/frontend-agent-chat",
   "extensions": {
     "wordpress": {}
   },

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -185,7 +185,7 @@ export default function AgentChat( {
 	const activeAgentSlug = selectedAgent?.slug ?? '';
 	const activeAgentName = selectedAgent?.name ?? agentName;
 	const activeAgentDescription = selectedAgent?.description ?? agentDescription;
-	const fabLabel = __( '🧠 Brain Chat', 'frontend-agent-chat' );
+	const fabLabel = __( 'Brain Chat', 'frontend-agent-chat' );
 	const agentFetch = useMemo( () => createAgentFetch( activeAgentSlug ), [ activeAgentSlug ] );
 	const open = useCallback( () => setIsOpen( true ), [] );
 	const close = useCallback( () => setIsOpen( false ), [] );
@@ -210,9 +210,9 @@ export default function AgentChat( {
 						return current;
 					}
 
-					const activeAgentSlug = data.active_agent_slug ?? '';
-					if ( activeAgentSlug && nextAgents.some( ( agent ) => agent.slug === activeAgentSlug ) ) {
-						return activeAgentSlug;
+					const preferredAgentSlug = data.active_agent_slug ?? '';
+					if ( preferredAgentSlug && nextAgents.some( ( agent ) => agent.slug === preferredAgentSlug ) ) {
+						return preferredAgentSlug;
 					}
 
 					return nextAgents[0].slug;
@@ -263,7 +263,8 @@ export default function AgentChat( {
 					activeAgentName
 				),
 			},
-			fabLabel,
+			createElement( 'span', { className: 'frontend-agent-chat__fab-icon', 'aria-hidden': true }, '🧠' ),
+			createElement( 'span', { className: 'frontend-agent-chat__fab-label' }, fabLabel ),
 			unreadCount > 0 &&
 				createElement(
 					'span',

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -19,6 +19,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	gap: 0.5rem;
 	height: 56px;
 	padding: 0 24px;
 	border: 1px solid var(--frontend-agent-chat-fab-border-color, transparent);
@@ -34,6 +35,17 @@
 	pointer-events: auto;
 	opacity: 1;
 	visibility: visible;
+}
+
+.frontend-agent-chat__fab-icon {
+	display: inline-flex;
+	font-size: 1.1em;
+	line-height: 1;
+}
+
+.frontend-agent-chat__fab-label {
+	display: inline-flex;
+	line-height: 1;
 }
 
 .frontend-agent-chat__fab:hover {


### PR DESCRIPTION
## Summary
- Split the brain emoji and Brain Chat label into separate launcher elements so spacing is controlled by layout instead of text rendering.
- Fix the Homeboy remote path for the active WP Cloud frontend chat plugin directory.

## Testing
- npm run typecheck
- npm run build
- homeboy lint --path /Users/chubes/Developer/data-machine-frontend-chat@fix-brain-chat-spacing --changed-since origin/main
- Deployed to the WP Cloud runtime and verified the build contains the split icon/label and FAB gap CSS.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the deployed regression, drafting the launcher spacing fix, running verification commands, and preparing this PR. Chris reviewed the live behavior and requested the fix.