### PR TITLE
Hide tool transcript messages in frontend chat

### DIFF
--- a/inc/rest.php
+++ b/inc/rest.php
@@ -553,6 +553,10 @@ function frontend_agent_chat_session_messages( array $source ): array {
 			continue;
 		}
 
+		if ( in_array( (string) ( $message['type'] ?? '' ), array( 'tool_call', 'tool_result' ), true ) ) {
+			continue;
+		}
+
 		$role = (string) $message['role'];
 		if ( ! in_array( $role, array( 'user', 'assistant' ), true ) ) {
 			continue;

--- a/tests/tool-transcript-message-filter-smoke.php
+++ b/tests/tool-transcript-message-filter-smoke.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Smoke tests for frontend transcript message filtering.
+ *
+ * @package FrontendAgentChat\Tests
+ */
+
+function frontend_agent_chat_tool_filter_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		return true;
+	}
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/rest.php';
+
+$messages = frontend_agent_chat_session_messages(
+	array(
+		'messages' => array(
+			array(
+				'role'    => 'user',
+				'type'    => 'text',
+				'content' => 'What do you know?',
+			),
+			array(
+				'role'    => 'assistant',
+				'type'    => 'tool_call',
+				'content' => 'AI ACTION (Turn 1): Executing Wiki Brain List.',
+			),
+			array(
+				'role'    => 'user',
+				'type'    => 'tool_result',
+				'content' => 'TOOL RESPONSE (Turn 1): SUCCESS.',
+			),
+			array(
+				'role'    => 'assistant',
+				'type'    => 'text',
+				'content' => 'Here is the answer.',
+			),
+		),
+	)
+);
+
+frontend_agent_chat_tool_filter_assert(
+	array(
+		array(
+			'role'    => 'user',
+			'content' => 'What do you know?',
+		),
+		array(
+			'role'    => 'assistant',
+			'content' => 'Here is the answer.',
+		),
+	) === $messages,
+	'Frontend transcript output should omit typed tool call/result messages.'
+);
+
+echo "Frontend tool transcript message filter smoke passed (1 assertion).\n";


### PR DESCRIPTION
## Summary
- Hide typed `tool_call` and `tool_result` messages when projecting stored sessions to frontend chat bubbles.
- Keep internal tool transcript entries available in storage while preventing raw `AI ACTION` / `TOOL RESPONSE` payloads from appearing in the widget.
- Add a focused smoke test for typed tool transcript filtering.

## Testing
- `php -l inc/rest.php && php -l tests/tool-transcript-message-filter-smoke.php`
- `php tests/tool-transcript-message-filter-smoke.php`
- `homeboy test --path . --extension wordpress` (activation/install passed; no PHPUnit tests discovered in current repo state)
- `homeboy lint --path . --extension wordpress` (fails on pre-existing unrelated findings in `inc/enqueue.php`, `inc/config.php`, and existing `inc/rest.php` static-analysis/formatting findings)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the frontend transcript projection leak, drafted the filter and smoke test, and ran local verification. Chris remains responsible for review and acceptance.