### PR TITLE
Allow principal-based frontend chat access

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -38,16 +38,12 @@ function frontend_agent_chat_get_config(): array {
 }
 
 /**
- * Check whether the current user can see the chat widget.
+ * Check whether the current request principal can see the chat widget.
  *
  * @param array|null $agent Resolved agent descriptor.
  * @return bool
  */
 function frontend_agent_chat_user_can_see( ?array $agent ): bool {
-	if ( ! is_user_logged_in() ) {
-		return false;
-	}
-
 	$agent_slug = frontend_agent_chat_get_agent_access_slug( $agent );
 	if ( '' === $agent_slug ) {
 		return false;
@@ -66,7 +62,7 @@ function frontend_agent_chat_user_can_see( ?array $agent ): bool {
 }
 
 /**
- * List accessible Agents API agents for the current user.
+ * List accessible Agents API agents for the current request principal.
  *
  * @return array<int,array{agent_slug:string,agent_name:string,agent_description:string,meta:array}>
  */

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -259,24 +259,6 @@ function frontend_agent_chat_rest_send_message( WP_REST_Request $request ) {
 		return new WP_Error( 'frontend_agent_chat_missing_agent', __( 'Agent is required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
 	}
 
-	if ( '' === $session_id ) {
-		$created = frontend_agent_chat_execute_ability(
-			'agents/create-conversation-session',
-			array(
-				'agent'   => $agent_slug,
-				'context' => 'frontend-agent-chat',
-			)
-		);
-		if ( is_wp_error( $created ) ) {
-			return $created;
-		}
-		$session_id = frontend_agent_chat_extract_session_id( is_array( $created['session'] ?? null ) ? $created['session'] : array() );
-	}
-
-	if ( '' === $session_id ) {
-		return new WP_Error( 'frontend_agent_chat_session_create_failed', __( 'The conversation session ability did not return a session ID.', 'frontend-agent-chat' ), array( 'status' => 500 ) );
-	}
-
 	$attachments = $request->get_param( 'attachments' );
 	$chat_input  = array(
 		'agent'          => $agent_slug,

--- a/tests/principal-access-smoke.php
+++ b/tests/principal-access-smoke.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Pure-PHP smoke test for principal-based frontend visibility.
+ *
+ * Run with: php tests/principal-access-smoke.php
+ *
+ * @package FrontendAgentChat
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+class WP_Agent_Access_Grant {
+	public const ROLE_VIEWER = 'viewer';
+}
+
+class FrontendAgentChatFakeAbility {
+	public function __construct( private string $name ) {}
+
+	public function execute( array $input ) {
+		$GLOBALS['frontend_agent_chat_smoke_calls'][] = array( $this->name, $input );
+
+		if ( 'agents/list-accessible-agents' === $this->name ) {
+			return array( 'agents' => $GLOBALS['frontend_agent_chat_smoke_agents'] );
+		}
+
+		if ( 'agents/can-access-agent' === $this->name ) {
+			return array( 'allowed' => $GLOBALS['frontend_agent_chat_smoke_allowed'] );
+		}
+
+		return array();
+	}
+}
+
+function __( $text, $domain = null ) {
+	unset( $domain );
+	return $text;
+}
+
+function sanitize_title( $value ) {
+	$value = strtolower( (string) $value );
+	$value = preg_replace( '/[^a-z0-9_-]+/', '-', $value );
+	return trim( (string) $value, '-' );
+}
+
+function apply_filters( $hook, $value ) {
+	unset( $hook );
+	return $value;
+}
+
+function get_option( $name, $default = false ) {
+	unset( $name );
+	return $default;
+}
+
+function is_multisite() {
+	return false;
+}
+
+function wp_get_ability( string $name ) {
+	return new FrontendAgentChatFakeAbility( $name );
+}
+
+function is_wp_error( $value ) {
+	return false;
+}
+
+require_once dirname( __DIR__ ) . '/inc/config.php';
+
+$failures = array();
+$passes   = 0;
+
+function frontend_agent_chat_smoke_assert_equals( $expected, $actual, string $message, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		return;
+	}
+
+	$failures[] = $message . ' expected ' . var_export( $expected, true ) . ' got ' . var_export( $actual, true );
+}
+
+echo "frontend-agent-chat-principal-access-smoke\n";
+
+$GLOBALS['frontend_agent_chat_smoke_calls']   = array();
+$GLOBALS['frontend_agent_chat_smoke_allowed'] = true;
+$GLOBALS['frontend_agent_chat_smoke_agents']  = array(
+	array(
+		'slug'        => 'wiki-brain',
+		'label'       => 'Wiki Brain',
+		'description' => 'Answers from the wiki.',
+	),
+);
+
+$agents = frontend_agent_chat_list_accessible_agents();
+frontend_agent_chat_smoke_assert_equals( 'wiki-brain', $agents[0]['agent_slug'] ?? '', 'accessible agents normalize from Agents API ability', $failures, $passes );
+frontend_agent_chat_smoke_assert_equals( true, frontend_agent_chat_user_can_see( $agents[0] ), 'visibility delegates to Agents API access without requiring a WP login', $failures, $passes );
+
+$GLOBALS['frontend_agent_chat_smoke_allowed'] = false;
+frontend_agent_chat_smoke_assert_equals( false, frontend_agent_chat_user_can_see( $agents[0] ), 'visibility fails closed when Agents API denies the current principal', $failures, $passes );
+
+$GLOBALS['frontend_agent_chat_smoke_agents'] = array();
+frontend_agent_chat_smoke_assert_equals( array(), frontend_agent_chat_list_accessible_agents(), 'no accessible principal grants means no agents', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo "Frontend principal access smoke passed ({$passes} assertions).\n";


### PR DESCRIPTION
## Summary
- Delegates widget visibility to Agents API access instead of requiring a logged-in WordPress user.
- Lets `agents/chat` create the first session so anonymous audience chats can run under the runtime-selected context.
- Adds a pure-PHP smoke test covering principal-based visibility.

## Testing
- `php tests/principal-access-smoke.php`
- `php -l inc/config.php`
- `php -l inc/rest.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented and tested the principal-based frontend chat access path under Chris's direction.