### PR TITLE
Persist logged-out chat sessions with browser principals

### DIFF
--- a/frontend-agent-chat.php
+++ b/frontend-agent-chat.php
@@ -25,6 +25,7 @@ define( 'FRONTEND_AGENT_CHAT_VERSION', '0.7.3' );
 define( 'FRONTEND_AGENT_CHAT_PLUGIN_FILE', __FILE__ );
 define( 'FRONTEND_AGENT_CHAT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FRONTEND_AGENT_CHAT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'FRONTEND_AGENT_CHAT_BROWSER_COOKIE', 'frontend_agent_chat_browser' );
 
 require_once FRONTEND_AGENT_CHAT_PLUGIN_DIR . 'inc/config.php';
 require_once FRONTEND_AGENT_CHAT_PLUGIN_DIR . 'inc/rest.php';

--- a/inc/config.php
+++ b/inc/config.php
@@ -90,12 +90,167 @@ function frontend_agent_chat_list_accessible_agents(): array {
  * @return string Active agent slug or empty string.
  */
 function frontend_agent_chat_get_active_agent_slug(): string {
+	if ( ! is_user_logged_in() ) {
+		$preferences = frontend_agent_chat_get_browser_preferences();
+		return sanitize_title( (string) ( $preferences['active_agent_slug'] ?? '' ) );
+	}
+
 	$result = frontend_agent_chat_execute_ability( 'datamachine/get-active-agent', array() );
 	if ( is_wp_error( $result ) || ! is_array( $result ) || empty( $result['success'] ) ) {
 		return '';
 	}
 
 	return sanitize_title( (string) ( $result['agent_slug'] ?? '' ) );
+}
+
+/**
+ * Persist an anonymous browser preference keyed by the browser principal.
+ *
+ * Logged-in users keep using Data Machine's normal user-owned preference.
+ *
+ * @param string $agent_slug Active agent slug.
+ * @return bool Whether the preference was stored.
+ */
+function frontend_agent_chat_set_browser_active_agent_slug( string $agent_slug ): bool {
+	if ( is_user_logged_in() ) {
+		return false;
+	}
+
+	$principal = frontend_agent_chat_get_browser_principal();
+	if ( ! $principal ) {
+		return false;
+	}
+
+	return update_option(
+		frontend_agent_chat_browser_preferences_option_name( $principal['id'] ),
+		array( 'active_agent_slug' => sanitize_title( $agent_slug ) ),
+		false
+	);
+}
+
+/**
+ * Read anonymous browser preferences.
+ *
+ * @return array Browser preference map.
+ */
+function frontend_agent_chat_get_browser_preferences(): array {
+	$principal = frontend_agent_chat_get_browser_principal();
+	if ( ! $principal ) {
+		return array();
+	}
+
+	$preferences = get_option( frontend_agent_chat_browser_preferences_option_name( $principal['id'] ), array() );
+	return is_array( $preferences ) ? $preferences : array();
+}
+
+/**
+ * Build the option name for browser-scoped preferences.
+ *
+ * @param string $principal_id Stable non-secret browser principal identifier.
+ * @return string Option name.
+ */
+function frontend_agent_chat_browser_preferences_option_name( string $principal_id ): string {
+	return 'frontend_agent_chat_browser_preferences_' . md5( $principal_id );
+}
+
+/**
+ * Ensure an anonymous browser principal cookie exists for this response.
+ *
+ * @return array|null Browser principal descriptor, or null for logged-in users/failures.
+ */
+function frontend_agent_chat_ensure_browser_principal_cookie(): ?array {
+	if ( is_user_logged_in() ) {
+		return null;
+	}
+
+	$token = frontend_agent_chat_get_browser_principal_token();
+	if ( '' === $token ) {
+		$token = wp_generate_password( 64, false, false );
+	}
+
+	frontend_agent_chat_set_browser_principal_cookie( $token );
+	return frontend_agent_chat_browser_principal_from_token( $token );
+}
+
+/**
+ * Get the current anonymous browser principal descriptor.
+ *
+ * @return array|null Browser principal descriptor, or null when unavailable.
+ */
+function frontend_agent_chat_get_browser_principal(): ?array {
+	if ( is_user_logged_in() ) {
+		return null;
+	}
+
+	$token = frontend_agent_chat_get_browser_principal_token();
+	return '' === $token ? null : frontend_agent_chat_browser_principal_from_token( $token );
+}
+
+/**
+ * Read and sanitize the browser principal token from the HttpOnly cookie.
+ *
+ * @return string Cookie token, or empty string.
+ */
+function frontend_agent_chat_get_browser_principal_token(): string {
+	$token = isset( $_COOKIE[ FRONTEND_AGENT_CHAT_BROWSER_COOKIE ] ) ? (string) wp_unslash( $_COOKIE[ FRONTEND_AGENT_CHAT_BROWSER_COOKIE ] ) : '';
+	return preg_match( '/^[A-Za-z0-9]{32,128}$/', $token ) ? $token : '';
+}
+
+/**
+ * Convert a cookie token into a non-secret principal descriptor.
+ *
+ * @param string $token Opaque browser token.
+ * @return array Browser principal descriptor.
+ */
+function frontend_agent_chat_browser_principal_from_token( string $token ): array {
+	return array(
+		'type'    => 'browser',
+		'id'      => 'browser:' . hash_hmac( 'sha256', $token, wp_salt( 'auth' ) ),
+		'context' => 'frontend-agent-chat',
+	);
+}
+
+/**
+ * Set the anonymous browser principal cookie.
+ *
+ * @param string $token Opaque browser token.
+ * @return void
+ */
+function frontend_agent_chat_set_browser_principal_cookie( string $token ): void {
+	$secure = (bool) apply_filters( 'frontend_agent_chat_browser_cookie_secure', true );
+	$path   = defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/';
+
+	setcookie(
+		FRONTEND_AGENT_CHAT_BROWSER_COOKIE,
+		$token,
+		array(
+			'expires'  => time() + YEAR_IN_SECONDS,
+			'path'     => $path,
+			'domain'   => defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : '',
+			'secure'   => $secure,
+			'httponly' => true,
+			'samesite' => 'Lax',
+		)
+	);
+
+	$_COOKIE[ FRONTEND_AGENT_CHAT_BROWSER_COOKIE ] = $token;
+}
+
+/**
+ * Add browser-principal context to ability input when available.
+ *
+ * @param array $input Ability input.
+ * @return array Ability input with browser principal context.
+ */
+function frontend_agent_chat_add_browser_principal_input( array $input ): array {
+	$principal = frontend_agent_chat_get_browser_principal();
+	if ( ! $principal ) {
+		return $input;
+	}
+
+	$input['principal']         = $principal;
+	$input['browser_principal'] = $principal;
+	return $input;
 }
 
 /**

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -67,9 +67,11 @@ function frontend_agent_chat_enqueue() {
 	$js_config = array(
 		'agentSlug'        => (string) ( $agent['agent_slug'] ?? $config['agent_slug'] ),
 		'basePath'         => '/frontend-agent-chat/v1/chat',
+		'bootstrapPath'    => '/frontend-agent-chat/v1/bootstrap',
 		'agentsPath'       => '/frontend-agent-chat/v1/agents',
 		'agentName'        => (string) ( $agent['agent_name'] ?? $agent['label'] ?? $config['agent_slug'] ),
 		'agentDescription' => (string) ( $agent['agent_description'] ?? $agent['description'] ?? $config['description'] ),
+		'isLoggedIn'       => is_user_logged_in(),
 	);
 
 	if ( ! empty( $config['loading_messages'] ) ) {

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -17,6 +17,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 function frontend_agent_chat_register_rest_routes(): void {
 	register_rest_route(
 		'frontend-agent-chat/v1',
+		'/bootstrap',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'frontend_agent_chat_rest_bootstrap',
+			'permission_callback' => 'frontend_agent_chat_rest_can_chat',
+		)
+	);
+
+	register_rest_route(
+		'frontend-agent-chat/v1',
 		'/agents',
 		array(
 			'methods'             => WP_REST_Server::READABLE,
@@ -112,6 +122,30 @@ function frontend_agent_chat_register_rest_routes(): void {
 add_action( 'rest_api_init', 'frontend_agent_chat_register_rest_routes' );
 
 /**
+ * Bootstrap browser-scoped state before anonymous session APIs are used.
+ *
+ * @return WP_REST_Response
+ */
+function frontend_agent_chat_rest_bootstrap(): WP_REST_Response {
+	$had_principal = null !== frontend_agent_chat_get_browser_principal();
+	$principal = frontend_agent_chat_ensure_browser_principal_cookie();
+
+	return rest_ensure_response(
+		array(
+			'success' => true,
+			'data'    => array(
+				'authenticated'             => is_user_logged_in(),
+				'browser_principal_ready'   => is_user_logged_in() || null !== $principal,
+				'had_browser_principal'     => $had_principal,
+				'browser_principal_id'      => is_array( $principal ) ? $principal['id'] : '',
+				'browser_principal_secret'  => false,
+				'session_persistence_scope' => is_user_logged_in() ? 'user' : 'browser',
+			)
+		)
+	);
+}
+
+/**
  * Permission callback for widget REST routes.
  *
  * @return bool
@@ -186,6 +220,22 @@ function frontend_agent_chat_rest_set_active_agent( WP_REST_Request $request ) {
 	}
 	if ( '' === $agent_slug ) {
 		return new WP_Error( 'frontend_agent_chat_missing_agent', __( 'Agent is required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+	}
+
+	if ( ! is_user_logged_in() ) {
+		if ( ! frontend_agent_chat_get_browser_principal() ) {
+			return new WP_Error( 'frontend_agent_chat_browser_principal_required', __( 'Browser chat storage needs cookies enabled.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+		}
+
+		frontend_agent_chat_set_browser_active_agent_slug( $agent_slug );
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'data'    => array(
+					'agent_slug' => $agent_slug,
+				)
+			)
+		);
 	}
 
 	$result = frontend_agent_chat_execute_ability( 'datamachine/set-active-agent', array( 'agent' => $agent_slug ) );
@@ -285,7 +335,8 @@ function frontend_agent_chat_rest_send_message( WP_REST_Request $request ) {
 	 */
 	$chat_input = apply_filters( 'frontend_agent_chat_chat_input', $chat_input, $request, $agent_slug, $config );
 
-	$result = frontend_agent_chat_execute_ability( 'agents/chat', is_array( $chat_input ) ? $chat_input : array() );
+	$chat_input = frontend_agent_chat_add_browser_principal_input( is_array( $chat_input ) ? $chat_input : array() );
+	$result     = frontend_agent_chat_execute_ability( 'agents/chat', $chat_input );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
@@ -351,11 +402,11 @@ function frontend_agent_chat_rest_resolve_pending_action( WP_REST_Request $reque
 
 	$result = frontend_agent_chat_execute_ability(
 		'agents/resolve-pending-action',
-		array(
+		frontend_agent_chat_add_browser_principal_input( array(
 			'action_id' => $action_id,
 			'decision'  => $decision,
 			'resolver'  => frontend_agent_chat_current_resolver_id(),
-		)
+		) )
 	);
 
 	if ( is_wp_error( $result ) ) {
@@ -387,11 +438,11 @@ function frontend_agent_chat_rest_list_sessions( WP_REST_Request $request ) {
 
 	$result      = frontend_agent_chat_execute_ability(
 		'agents/list-conversation-sessions',
-		array(
+		frontend_agent_chat_add_browser_principal_input( array(
 			'limit'   => $limit,
 			'agent'   => $agent_slug,
 			'context' => 'frontend-agent-chat',
-		)
+		) )
 	);
 
 	if ( is_wp_error( $result ) ) {
@@ -420,7 +471,7 @@ function frontend_agent_chat_rest_list_sessions( WP_REST_Request $request ) {
  */
 function frontend_agent_chat_rest_get_session( WP_REST_Request $request ) {
 	$session_id = sanitize_text_field( (string) $request['session_id'] );
-	$result     = frontend_agent_chat_execute_ability( 'agents/get-conversation-session', array( 'session_id' => $session_id ) );
+	$result     = frontend_agent_chat_execute_ability( 'agents/get-conversation-session', frontend_agent_chat_add_browser_principal_input( array( 'session_id' => $session_id ) ) );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -446,7 +497,7 @@ function frontend_agent_chat_rest_get_session( WP_REST_Request $request ) {
  */
 function frontend_agent_chat_rest_delete_session( WP_REST_Request $request ) {
 	$session_id = sanitize_text_field( (string) $request['session_id'] );
-	$result     = frontend_agent_chat_execute_ability( 'agents/delete-conversation-session', array( 'session_id' => $session_id ) );
+	$result     = frontend_agent_chat_execute_ability( 'agents/delete-conversation-session', frontend_agent_chat_add_browser_principal_input( array( 'session_id' => $session_id ) ) );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -36,14 +36,38 @@ import apiFetch from '@wordpress/api-fetch';
 interface AgentChatProps {
 	agentSlug?: string;
 	basePath: string;
+	bootstrapPath?: string;
 	agentsPath: string;
 	agentName: string;
 	agentDescription: string;
+	isLoggedIn?: boolean;
 	loadingMessages?: boolean | {
 		mode?: 'default' | 'extend' | 'override';
 		messages?: string[];
 		interval?: number;
 	};
+}
+
+interface BootstrapResponse {
+	success?: boolean;
+	data?: {
+		authenticated?: boolean;
+		browser_principal_ready?: boolean;
+		had_browser_principal?: boolean;
+		session_persistence_scope?: 'user' | 'browser';
+	};
+}
+
+async function bootstrapBrowserPrincipal( bootstrapPath: string ): Promise< boolean > {
+	const response = await apiFetch( { path: bootstrapPath, method: 'POST' } ) as BootstrapResponse;
+	const data = response.data ?? {};
+	if ( data.authenticated || data.had_browser_principal ) {
+		return data.browser_principal_ready !== false;
+	}
+
+	const verificationResponse = await apiFetch( { path: bootstrapPath, method: 'POST' } ) as BootstrapResponse;
+	const verificationData = verificationResponse.data ?? {};
+	return verificationData.browser_principal_ready !== false && verificationData.had_browser_principal === true;
 }
 
 interface AgentSummary {
@@ -164,13 +188,17 @@ function renderDiffCard( group: ToolGroup ): ReactNode {
 export default function AgentChat( {
 	agentSlug,
 	basePath,
+	bootstrapPath = '/frontend-agent-chat/v1/bootstrap',
 	agentsPath,
 	agentName,
 	agentDescription,
+	isLoggedIn = false,
 	loadingMessages = true,
 }: AgentChatProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ unreadCount, setUnreadCount ] = useState( 0 );
+	const [ browserBootstrapReady, setBrowserBootstrapReady ] = useState( isLoggedIn );
+	const [ browserBootstrapFailed, setBrowserBootstrapFailed ] = useState( false );
 	const [ agents, setAgents ] = useState< AgentSummary[] >( () => agentSlug ? [ {
 		slug: agentSlug,
 		name: agentName,
@@ -194,6 +222,25 @@ export default function AgentChat( {
 		setSelectedAgentSlug( nextAgentSlug );
 		persistActiveAgent( nextAgentSlug );
 	}, [] );
+
+	useEffect( () => {
+		if ( isLoggedIn ) {
+			setBrowserBootstrapReady( true );
+			return;
+		}
+
+		bootstrapBrowserPrincipal( bootstrapPath )
+			.then( ( ready ) => {
+				setBrowserBootstrapReady( ready );
+				setBrowserBootstrapFailed( ! ready );
+			} )
+			.catch( ( err: unknown ) => {
+				setBrowserBootstrapReady( false );
+				setBrowserBootstrapFailed( true );
+				// eslint-disable-next-line no-console
+				console.error( 'AgentChat: failed to bootstrap browser chat storage', err );
+			} );
+	}, [ bootstrapPath, isLoggedIn ] );
 
 	useEffect( () => {
 		apiFetch( { path: agentsPath } )
@@ -317,12 +364,19 @@ export default function AgentChat( {
 			createElement(
 				'div',
 				{ className: 'frontend-agent-chat__body' },
+				! isLoggedIn && createElement(
+					'div',
+					{ className: `frontend-agent-chat__persistence${ browserBootstrapFailed ? ' has-warning' : '' }` },
+					browserBootstrapFailed
+						? __( 'Chat works, but this browser is blocking secure chat-history cookies.', 'frontend-agent-chat' )
+						: __( 'This browser can keep chat history with a secure cookie. Sign in with WordPress.com to save chat history across devices.', 'frontend-agent-chat' )
+				),
 				activeAgentSlug && createElement( Chat, {
 					key: activeAgentSlug,
 					basePath,
 					fetchFn: agentFetch,
 					showTools: true,
-					showSessions: true,
+					showSessions: isLoggedIn || browserBootstrapReady,
 					toolRenderers,
 					placeholder: sprintf(
 						/* translators: %s: agent name. */

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -190,6 +190,8 @@
 .frontend-agent-chat__body {
 	flex: 1;
 	min-height: 0;
+	display: flex;
+	flex-direction: column;
 	overflow: hidden;
 }
 
@@ -214,7 +216,24 @@
 	--ec-chat-border-radius: 0;
 
 	height: 100%;
+	min-height: 0;
 	border-radius: 0;
+}
+
+.frontend-agent-chat__persistence {
+	padding: 8px 16px;
+	border-bottom: 1px solid var(--frontend-agent-chat-border-color, #e2e8f0);
+	background: var(--frontend-agent-chat-bg-muted, #f8fafc);
+	color: var(--frontend-agent-chat-text-muted, #64748b);
+	font-family: var(--frontend-agent-chat-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+	font-size: 12px;
+	line-height: 1.4;
+	flex-shrink: 0;
+}
+
+.frontend-agent-chat__persistence.has-warning {
+	color: var(--frontend-agent-chat-warning-text, #92400e);
+	background: var(--frontend-agent-chat-warning-bg, #fef3c7);
 }
 
 .frontend-agent-chat__empty {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,9 +30,11 @@ declare global {
 		frontendAgentChatConfig?: {
 			agentSlug?: string;
 			basePath: string;
+			bootstrapPath?: string;
 			agentsPath: string;
 			agentName: string;
 			agentDescription: string;
+			isLoggedIn?: boolean;
 			loadingMessages?: boolean | {
 				mode?: 'default' | 'extend' | 'override';
 				messages?: string[];
@@ -71,9 +73,11 @@ function init(): void {
 		createElement( AgentChat, {
 			agentSlug: config.agentSlug,
 			basePath: config.basePath,
+			bootstrapPath: config.bootstrapPath,
 			agentsPath: config.agentsPath,
 			agentName: config.agentName,
 			agentDescription: config.agentDescription,
+			isLoggedIn: config.isLoggedIn ?? false,
 			loadingMessages: config.loadingMessages ?? true,
 		} )
 	);


### PR DESCRIPTION
## Summary
- Add logged-out browser-principal bootstrap using an opaque HttpOnly cookie.
- Pass validated browser-principal context through frontend chat requests without exposing the cookie secret to JavaScript.
- Add logged-out persistence messaging and cookie-blocking fallback copy.

## Dependency
- Depends on Agents API principal-owned conversation sessions: https://github.com/Automattic/agents-api/pull/175
- Depends on Data Machine transcript owner isolation: https://github.com/Extra-Chill/data-machine/pull/2024
- Tracks https://github.com/Extra-Chill/frontend-agent-chat/issues/19.

## Testing
- `npm run typecheck`
- `npm run build`
- `php -l frontend-agent-chat.php && php -l inc/config.php && php -l inc/rest.php && php -l inc/enqueue.php`
- `php tests/principal-access-smoke.php`
- `php tests/tool-transcript-message-filter-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the implementation, browser-session UX, and PR description; Chris remains responsible for review and validation.