### PR TITLE
Pass browser transcript owner to chat runtime

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -250,6 +250,11 @@ function frontend_agent_chat_add_browser_principal_input( array $input ): array 
 
 	$input['principal']         = $principal;
 	$input['browser_principal'] = $principal;
+	$input['transcript_owner']  = array(
+		'type'  => 'browser',
+		'key'   => $principal['id'],
+		'label' => 'Browser chat session',
+	);
 	return $input;
 }
 


### PR DESCRIPTION
## Summary
- Include the explicit `transcript_owner` payload Data Machine expects when Frontend Agent Chat has validated an anonymous browser principal.
- Keep the existing `principal` and `browser_principal` descriptors for the generic Agents API/browser-principal path.

## Testing
- `php -l inc/config.php`
- `php tests/principal-access-smoke.php`
- `npm run typecheck`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the deployed bridge mismatch and drafting the compatibility fix; Chris remains responsible for review and validation.