### PR TITLE
Send browser execution principal for session APIs

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -248,7 +248,21 @@ function frontend_agent_chat_add_browser_principal_input( array $input ): array 
 		return $input;
 	}
 
-	$input['principal']         = $principal;
+	$agent_slug = sanitize_title( (string) ( $input['agent'] ?? '' ) );
+
+	$input['principal']         = array(
+		'acting_user_id'     => 0,
+		'effective_agent_id' => '' !== $agent_slug ? $agent_slug : 'frontend-agent-chat',
+		'auth_source'        => 'audience',
+		'request_context'    => 'rest',
+		'client_id'          => 'frontend-agent-chat',
+		'audience_id'        => 'browser',
+		'audience_claims'    => array(
+			'browser_principal_id' => $principal['id'],
+		),
+		'owner_type'         => 'browser',
+		'owner_key'          => $principal['id'],
+	);
 	$input['browser_principal'] = $principal;
 	$input['transcript_owner']  = array(
 		'type'  => 'browser',


### PR DESCRIPTION
## Summary
- Send a full Agents API execution-principal payload for validated anonymous browser sessions.
- Preserve the explicit Data Machine `transcript_owner` payload and short browser descriptor.

## Testing
- `php -l inc/config.php`
- `php tests/principal-access-smoke.php`
- `npm run typecheck`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the deployed anonymous session-list bridge mismatch and drafting the minimal frontend principal payload fix; Chris remains responsible for review and validation.