### PR TITLE
Expose generic chat persistence CTA

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -74,6 +74,27 @@ function frontend_agent_chat_enqueue() {
 		'isLoggedIn'       => is_user_logged_in(),
 	);
 
+	/**
+	 * Filter anonymous chat persistence CTA data.
+	 *
+	 * Domain plugins can provide a product-specific sign-in or account-linking
+	 * action without coupling this generic widget to a concrete identity provider.
+	 * Return an array with `message`, `action_label`, and `action_url`, or an empty
+	 * array to show the generic browser-cookie persistence message.
+	 *
+	 * @param array $cta    CTA data.
+	 * @param array $config Frontend chat configuration.
+	 * @param array $agent  Selected agent descriptor.
+	 */
+	$persistence_cta = apply_filters( 'frontend_agent_chat_persistence_cta', array(), $config, $agent );
+	if ( is_array( $persistence_cta ) && ! empty( $persistence_cta['action_url'] ) ) {
+		$js_config['persistenceCta'] = array(
+			'message'     => sanitize_text_field( (string) ( $persistence_cta['message'] ?? '' ) ),
+			'actionLabel' => sanitize_text_field( (string) ( $persistence_cta['action_label'] ?? '' ) ),
+			'actionUrl'   => esc_url_raw( (string) $persistence_cta['action_url'] ),
+		);
+	}
+
 	if ( ! empty( $config['loading_messages'] ) ) {
 		$js_config['loadingMessages'] = $config['loading_messages'];
 	}

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -46,6 +46,11 @@ interface AgentChatProps {
 		messages?: string[];
 		interval?: number;
 	};
+	persistenceCta?: {
+		message?: string;
+		actionLabel?: string;
+		actionUrl?: string;
+	};
 }
 
 interface BootstrapResponse {
@@ -194,6 +199,7 @@ export default function AgentChat( {
 	agentDescription,
 	isLoggedIn = false,
 	loadingMessages = true,
+	persistenceCta,
 }: AgentChatProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ unreadCount, setUnreadCount ] = useState( 0 );
@@ -294,6 +300,9 @@ export default function AgentChat( {
 		} ),
 		[]
 	);
+	const persistenceMessage = browserBootstrapFailed
+		? __( 'Chat works, but this browser is blocking secure chat-history cookies.', 'frontend-agent-chat' )
+		: ( persistenceCta?.message || __( 'This browser can keep chat history with a secure cookie.', 'frontend-agent-chat' ) );
 
 	return createElement(
 		'div',
@@ -367,9 +376,15 @@ export default function AgentChat( {
 				! isLoggedIn && createElement(
 					'div',
 					{ className: `frontend-agent-chat__persistence${ browserBootstrapFailed ? ' has-warning' : '' }` },
-					browserBootstrapFailed
-						? __( 'Chat works, but this browser is blocking secure chat-history cookies.', 'frontend-agent-chat' )
-						: __( 'This browser can keep chat history with a secure cookie. Sign in with WordPress.com to save chat history across devices.', 'frontend-agent-chat' )
+					persistenceMessage,
+					! browserBootstrapFailed && persistenceCta?.actionUrl && persistenceCta?.actionLabel && createElement(
+						'a',
+						{
+							className: 'frontend-agent-chat__persistence-action',
+							href: persistenceCta.actionUrl,
+						},
+						persistenceCta.actionLabel
+					)
 				),
 				activeAgentSlug && createElement( Chat, {
 					key: activeAgentSlug,

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -236,6 +236,18 @@
 	background: var(--frontend-agent-chat-warning-bg, #fef3c7);
 }
 
+.frontend-agent-chat__persistence-action {
+	display: inline-flex;
+	margin-left: 0.35rem;
+	color: var(--frontend-agent-chat-accent, #2563eb);
+	font-weight: 700;
+	text-decoration: none;
+}
+
+.frontend-agent-chat__persistence-action:hover {
+	text-decoration: underline;
+}
+
 .frontend-agent-chat__empty {
 	text-align: center;
 	padding: var(--frontend-agent-chat-spacing-lg, 24px);

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,11 @@ declare global {
 				messages?: string[];
 				interval?: number;
 			};
+			persistenceCta?: {
+				message?: string;
+				actionLabel?: string;
+				actionUrl?: string;
+			};
 		};
 	}
 }
@@ -79,6 +84,7 @@ function init(): void {
 			agentDescription: config.agentDescription,
 			isLoggedIn: config.isLoggedIn ?? false,
 			loadingMessages: config.loadingMessages ?? true,
+			persistenceCta: config.persistenceCta,
 		} )
 	);
 }


### PR DESCRIPTION
## Summary
- Remove provider-specific WordPress.com copy from the generic frontend chat widget.
- Add `frontend_agent_chat_persistence_cta` so domain plugins can provide a sign-in/account-linking CTA.
- Render a generic persistence message when no domain CTA is configured.

## Testing
- `npm install`
- `npm run typecheck`
- `npm run build`
- `php -l inc/enqueue.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Removing provider-specific UI coupling and adding the generic filter/rendering path; Chris remains responsible for review and validation.