### PR TITLE
Support request-scoped default chat agents

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -70,7 +70,8 @@ function frontend_agent_chat_list_accessible_agents(): array {
 	$minimum_role = class_exists( 'WP_Agent_Access_Grant' ) ? WP_Agent_Access_Grant::ROLE_VIEWER : 'viewer';
 	$result       = frontend_agent_chat_execute_ability( 'agents/list-accessible-agents', array( 'minimum_role' => $minimum_role ) );
 	$agents       = is_array( $result ) && is_array( $result['agents'] ?? null ) ? $result['agents'] : array();
-	$normalized   = array();
+	/** @var array<int,array{agent_slug:string,agent_name:string,agent_description:string,meta:array}> $normalized */
+	$normalized = array();
 
 	foreach ( $agents as $agent ) {
 		$agent = frontend_agent_chat_normalize_agent( is_array( $agent ) ? $agent : array() );
@@ -101,6 +102,29 @@ function frontend_agent_chat_get_active_agent_slug(): string {
 	}
 
 	return sanitize_title( (string) ( $result['agent_slug'] ?? '' ) );
+}
+
+/**
+ * Resolve the default frontend chat agent for the current request.
+ *
+ * This is intentionally separate from the persisted active agent preference:
+ * integrations can make the first-open default match the current page while
+ * still allowing users to switch agents in the widget.
+ *
+ * @param array|null $config Frontend chat configuration, or null to load it.
+ * @return string Default agent slug or empty string.
+ */
+function frontend_agent_chat_get_default_agent_slug( ?array $config = null ): string {
+	$config       = is_array( $config ) ? $config : frontend_agent_chat_get_config();
+	$default_slug = sanitize_title( (string) ( $config['agent_slug'] ?? '' ) );
+
+	/**
+	 * Filter the default frontend chat agent for the current request.
+	 *
+	 * @param string $default_slug Default agent slug.
+	 * @param array  $config       Frontend chat configuration.
+	 */
+	return sanitize_title( (string) apply_filters( 'frontend_agent_chat_default_agent_slug', $default_slug, $config ) );
 }
 
 /**
@@ -276,7 +300,7 @@ function frontend_agent_chat_add_browser_principal_input( array $input ): array 
  * Normalize an Agents API descriptor for frontend chat use.
  *
  * @param array $agent Raw agent descriptor.
- * @return array|null Normalized descriptor or null.
+ * @return array{agent_slug:string,agent_name:string,agent_description:string,meta:array}|null Normalized descriptor or null.
  */
 function frontend_agent_chat_normalize_agent( array $agent ): ?array {
 	$slug = sanitize_title( (string) ( $agent['slug'] ?? $agent['agent_slug'] ?? '' ) );

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -31,11 +31,12 @@ function frontend_agent_chat_enqueue() {
 		return;
 	}
 
-	$agent = null;
-	if ( ! empty( $config['agent_slug'] ) ) {
-		$agent = frontend_agent_chat_resolve_agent( (string) $config['agent_slug'] );
+	$default_agent_slug = frontend_agent_chat_get_default_agent_slug( $config );
+	$agent              = null;
+	if ( '' !== $default_agent_slug ) {
+		$agent = frontend_agent_chat_resolve_agent( $default_agent_slug );
 	}
-	$agent = $agent ?: $agents[0];
+	$agent = $agent ? $agent : $agents[0];
 
 	$build_dir = FRONTEND_AGENT_CHAT_PLUGIN_DIR . 'build/';
 	$build_url = FRONTEND_AGENT_CHAT_PLUGIN_URL . 'build/';
@@ -65,11 +66,11 @@ function frontend_agent_chat_enqueue() {
 	}
 
 	$js_config = array(
-		'agentSlug'        => (string) ( $agent['agent_slug'] ?? $config['agent_slug'] ),
+		'agentSlug'        => (string) ( $agent['agent_slug'] ?? $default_agent_slug ),
 		'basePath'         => '/frontend-agent-chat/v1/chat',
 		'bootstrapPath'    => '/frontend-agent-chat/v1/bootstrap',
 		'agentsPath'       => '/frontend-agent-chat/v1/agents',
-		'agentName'        => (string) ( $agent['agent_name'] ?? $agent['label'] ?? $config['agent_slug'] ),
+		'agentName'        => (string) ( $agent['agent_name'] ?? $agent['label'] ?? $default_agent_slug ),
 		'agentDescription' => (string) ( $agent['agent_description'] ?? $agent['description'] ?? $config['description'] ),
 		'isLoggedIn'       => is_user_logged_in(),
 	);
@@ -86,6 +87,7 @@ function frontend_agent_chat_enqueue() {
 	 * @param array $config Frontend chat configuration.
 	 * @param array $agent  Selected agent descriptor.
 	 */
+	/** @var mixed $persistence_cta */
 	$persistence_cta = apply_filters( 'frontend_agent_chat_persistence_cta', array(), $config, $agent );
 	if ( is_array( $persistence_cta ) && ! empty( $persistence_cta['action_url'] ) ) {
 		$js_config['persistenceCta'] = array(

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -128,7 +128,7 @@ add_action( 'rest_api_init', 'frontend_agent_chat_register_rest_routes' );
  */
 function frontend_agent_chat_rest_bootstrap(): WP_REST_Response {
 	$had_principal = null !== frontend_agent_chat_get_browser_principal();
-	$principal = frontend_agent_chat_ensure_browser_principal_cookie();
+	$principal     = frontend_agent_chat_ensure_browser_principal_cookie();
 
 	return rest_ensure_response(
 		array(
@@ -140,7 +140,7 @@ function frontend_agent_chat_rest_bootstrap(): WP_REST_Response {
 				'browser_principal_id'      => is_array( $principal ) ? $principal['id'] : '',
 				'browser_principal_secret'  => false,
 				'session_persistence_scope' => is_user_logged_in() ? 'user' : 'browser',
-			)
+			),
 		)
 	);
 }
@@ -159,7 +159,8 @@ function frontend_agent_chat_rest_can_chat( ?WP_REST_Request $request = null ): 
 		return ! empty( frontend_agent_chat_list_accessible_agents() );
 	}
 
-	$agent_slug = $request ? frontend_agent_chat_rest_get_agent_slug( $request, (string) ( $config['agent_slug'] ?? '' ) ) : (string) ( $config['agent_slug'] ?? '' );
+	$default_agent_slug = frontend_agent_chat_get_default_agent_slug( $config );
+	$agent_slug         = $request ? frontend_agent_chat_rest_get_agent_slug( $request, $default_agent_slug ) : $default_agent_slug;
 	if ( '' === $agent_slug ) {
 		return ! empty( frontend_agent_chat_list_accessible_agents() );
 	}
@@ -178,14 +179,17 @@ function frontend_agent_chat_rest_can_chat( ?WP_REST_Request $request = null ): 
  * @return WP_REST_Response
  */
 function frontend_agent_chat_rest_list_agents(): WP_REST_Response {
-	$agents      = frontend_agent_chat_list_accessible_agents();
-	$active_slug = frontend_agent_chat_get_active_agent_slug();
+	$config       = frontend_agent_chat_get_config();
+	$agents       = frontend_agent_chat_list_accessible_agents();
+	$active_slug  = frontend_agent_chat_get_active_agent_slug();
+	$default_slug = frontend_agent_chat_get_default_agent_slug( $config );
 	return rest_ensure_response(
 		array(
 			'success' => true,
 			'data'    => array(
-				'active_agent_slug' => $active_slug,
-				'agents'            => array_map( 'frontend_agent_chat_rest_agent_summary', $agents ),
+				'active_agent_slug'  => $active_slug,
+				'default_agent_slug' => $default_slug,
+				'agents'             => array_map( 'frontend_agent_chat_rest_agent_summary', $agents ),
 			),
 		)
 	);
@@ -233,7 +237,7 @@ function frontend_agent_chat_rest_set_active_agent( WP_REST_Request $request ) {
 				'success' => true,
 				'data'    => array(
 					'agent_slug' => $agent_slug,
-				)
+				),
 			)
 		);
 	}
@@ -302,9 +306,9 @@ function frontend_agent_chat_rest_send_message( WP_REST_Request $request ) {
 		return new WP_Error( 'frontend_agent_chat_empty_message', __( 'Message cannot be empty.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
 	}
 
-	$config      = frontend_agent_chat_get_config();
-	$agent_slug  = frontend_agent_chat_rest_get_agent_slug( $request, (string) ( $config['agent_slug'] ?? '' ) );
-	$session_id  = sanitize_text_field( (string) $request->get_param( 'session_id' ) );
+	$config     = frontend_agent_chat_get_config();
+	$agent_slug = frontend_agent_chat_rest_get_agent_slug( $request, frontend_agent_chat_get_default_agent_slug( $config ) );
+	$session_id = sanitize_text_field( (string) $request->get_param( 'session_id' ) );
 	if ( '' === $agent_slug ) {
 		return new WP_Error( 'frontend_agent_chat_missing_agent', __( 'Agent is required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
 	}
@@ -333,6 +337,7 @@ function frontend_agent_chat_rest_send_message( WP_REST_Request $request ) {
 	 * @param string          $agent_slug Selected agent slug.
 	 * @param array           $config     Frontend chat configuration.
 	 */
+	/** @var mixed $chat_input */
 	$chat_input = apply_filters( 'frontend_agent_chat_chat_input', $chat_input, $request, $agent_slug, $config );
 
 	$chat_input = frontend_agent_chat_add_browser_principal_input( is_array( $chat_input ) ? $chat_input : array() );
@@ -431,7 +436,7 @@ function frontend_agent_chat_rest_list_sessions( WP_REST_Request $request ) {
 	$config      = frontend_agent_chat_get_config();
 	$limit_param = $request->get_param( 'limit' );
 	$limit       = max( 1, min( 100, (int) ( null !== $limit_param ? $limit_param : 20 ) ) );
-	$agent_slug  = frontend_agent_chat_rest_get_agent_slug( $request, (string) ( $config['agent_slug'] ?? '' ) );
+	$agent_slug  = frontend_agent_chat_rest_get_agent_slug( $request, frontend_agent_chat_get_default_agent_slug( $config ) );
 	if ( '' === $agent_slug ) {
 		return new WP_Error( 'frontend_agent_chat_missing_agent', __( 'Agent is required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
 	}
@@ -453,6 +458,7 @@ function frontend_agent_chat_rest_list_sessions( WP_REST_Request $request ) {
 	 * @param string          $agent_slug Selected agent slug.
 	 * @param array           $config     Frontend chat configuration.
 	 */
+	/** @var mixed $list_input */
 	$list_input = apply_filters( 'frontend_agent_chat_session_list_input', $list_input, $request, $agent_slug, $config );
 
 	$result = frontend_agent_chat_execute_ability(

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -85,6 +85,7 @@ interface AgentsResponse {
 	success?: boolean;
 	data?: {
 		active_agent_slug?: string;
+		default_agent_slug?: string;
 		agents?: AgentSummary[];
 	};
 }
@@ -261,6 +262,11 @@ export default function AgentChat( {
 				setSelectedAgentSlug( ( current ) => {
 					if ( current && nextAgents.some( ( agent ) => agent.slug === current ) ) {
 						return current;
+					}
+
+					const defaultAgentSlug = data.default_agent_slug ?? '';
+					if ( defaultAgentSlug && nextAgents.some( ( agent ) => agent.slug === defaultAgentSlug ) ) {
+						return defaultAgentSlug;
 					}
 
 					const preferredAgentSlug = data.active_agent_slug ?? '';


### PR DESCRIPTION
## Summary
- Adds a generic `frontend_agent_chat_default_agent_slug` filter for request-scoped default agent selection.
- Uses the filtered default for initial widget localization and REST fallback agent resolution.
- Returns `default_agent_slug` from the agents endpoint so the selector can prefer page context without overwriting persisted active-agent preferences.

## Testing
- `npm run typecheck`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the hook implementation, TypeScript selection update, and focused verification; Chris to review and test before merge.
