### PR TITLE
Add expanded frontend chat viewport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "^0.11.0"
+				"@extrachill/chat": "^0.12.1"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2656,9 +2656,9 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.11.0.tgz",
-			"integrity": "sha512-wOskWB9SucQKGWmMfC98Fvyeg7cIBmYoeZtrh06RBKZTtSJP0JL5TYnANYsyf578jOX7y9KzLt3i/LCHbu9Cjg==",
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.12.1.tgz",
+			"integrity": "sha512-c5K37JjanEYhVa9DItSmEkD8GTesGp3hTKOojRx0Xd9KoIxgsJABGSxCGj+TSfTql9ocIsiRTHv6p4wpHuSgGQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "^0.11.0"
+		"@extrachill/chat": "^0.12.1"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -203,6 +203,7 @@ export default function AgentChat( {
 	persistenceCta,
 }: AgentChatProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
+	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ unreadCount, setUnreadCount ] = useState( 0 );
 	const [ browserBootstrapReady, setBrowserBootstrapReady ] = useState( isLoggedIn );
 	const [ browserBootstrapFailed, setBrowserBootstrapFailed ] = useState( false );
@@ -223,7 +224,11 @@ export default function AgentChat( {
 	const fabLabel = __( 'Brain Chat', 'frontend-agent-chat' );
 	const agentFetch = useMemo( () => createAgentFetch( activeAgentSlug ), [ activeAgentSlug ] );
 	const open = useCallback( () => setIsOpen( true ), [] );
-	const close = useCallback( () => setIsOpen( false ), [] );
+	const close = useCallback( () => {
+		setIsOpen( false );
+		setIsExpanded( false );
+	}, [] );
+	const toggleExpanded = useCallback( () => setIsExpanded( ( expanded ) => ! expanded ), [] );
 	const switchAgent = useCallback( ( event: ChangeEvent< HTMLSelectElement > ) => {
 		const nextAgentSlug = event.target.value;
 		setSelectedAgentSlug( nextAgentSlug );
@@ -287,16 +292,23 @@ export default function AgentChat( {
 		setUnreadCount( 0 );
 	}, [ activeAgentSlug ] );
 
-	// Close drawer on Escape key.
+	// Escape exits expanded mode first, then closes the drawer.
 	useEffect( () => {
 		function handleKeyDown( e: KeyboardEvent ) {
-			if ( e.key === 'Escape' && isOpen ) {
-				setIsOpen( false );
+			if ( e.key !== 'Escape' || ! isOpen ) {
+				return;
 			}
+
+			if ( isExpanded ) {
+				setIsExpanded( false );
+				return;
+			}
+
+			setIsOpen( false );
 		}
 		document.addEventListener( 'keydown', handleKeyDown );
 		return () => document.removeEventListener( 'keydown', handleKeyDown );
-	}, [ isOpen ] );
+	}, [ isExpanded, isOpen ] );
 
 	const toolRenderers = useMemo(
 		() => ( {
@@ -309,6 +321,9 @@ export default function AgentChat( {
 	const persistenceMessage = browserBootstrapFailed
 		? __( 'Chat works, but this browser is blocking secure chat-history cookies.', 'frontend-agent-chat' )
 		: ( persistenceCta?.message || __( 'This browser can keep chat history with a secure cookie.', 'frontend-agent-chat' ) );
+	const expandedButtonLabel = isExpanded
+		? __( 'Exit expanded chat view', 'frontend-agent-chat' )
+		: __( 'Expand chat to viewport', 'frontend-agent-chat' );
 
 	return createElement(
 		'div',
@@ -337,7 +352,7 @@ export default function AgentChat( {
 		createElement(
 			'div',
 			{
-				className: `frontend-agent-chat__drawer${ isOpen ? ' is-open' : '' }`,
+				className: `frontend-agent-chat__drawer${ isOpen ? ' is-open' : '' }${ isExpanded ? ' is-expanded' : '' }`,
 				'aria-hidden': ! isOpen,
 			},
 			createElement(
@@ -366,14 +381,29 @@ export default function AgentChat( {
 					)
 				),
 				createElement(
-					'button',
-					{
-						type: 'button',
-						className: 'frontend-agent-chat__close',
-						onClick: close,
-						'aria-label': __( 'Close', 'frontend-agent-chat' ),
-					},
-					'\u00D7'
+					'div',
+					{ className: 'frontend-agent-chat__header-actions' },
+					createElement(
+						'button',
+						{
+							type: 'button',
+							className: 'frontend-agent-chat__expand',
+							onClick: toggleExpanded,
+							'aria-label': expandedButtonLabel,
+							'aria-pressed': isExpanded,
+						},
+						isExpanded ? '\u2199' : '\u2197'
+					),
+					createElement(
+						'button',
+						{
+							type: 'button',
+							className: 'frontend-agent-chat__close',
+							onClick: close,
+							'aria-label': __( 'Close', 'frontend-agent-chat' ),
+						},
+						'\u00D7'
+					)
 				)
 			),
 			createElement(

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -87,6 +87,10 @@
 	top: var(--wp-admin--admin-bar--height, 32px);
 }
 
+.admin-bar .frontend-agent-chat__drawer.is-expanded {
+	top: 0;
+}
+
 @media (max-width: 782px) {
 	.admin-bar .frontend-agent-chat__drawer {
 		top: 0;
@@ -115,6 +119,11 @@
 	transform: translateX(0);
 	visibility: visible;
 	transition: transform 0.25s ease, visibility 0s 0s;
+}
+
+.frontend-agent-chat__drawer.is-expanded {
+	max-width: none;
+	border-left: none;
 }
 
 .frontend-agent-chat__drawer:not(.is-open) {
@@ -168,6 +177,14 @@
 	outline-offset: 2px;
 }
 
+.frontend-agent-chat__header-actions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+}
+
+.frontend-agent-chat__expand,
 .frontend-agent-chat__close {
 	display: flex;
 	align-items: center;
@@ -183,8 +200,15 @@
 	transition: background 0.15s;
 }
 
+.frontend-agent-chat__expand:hover,
 .frontend-agent-chat__close:hover {
 	background: var(--frontend-agent-chat-bg-muted, #f8fafc);
+}
+
+.frontend-agent-chat__expand:focus,
+.frontend-agent-chat__close:focus {
+	outline: 2px solid var(--frontend-agent-chat-accent, #2563eb);
+	outline-offset: 2px;
 }
 
 .frontend-agent-chat__body {


### PR DESCRIPTION
## Summary
- Add a header control that toggles the frontend chat drawer into a browser-viewport expanded mode.
- Keep the existing drawer default, close button, agent switcher, sessions, persistence CTA, unread count, and browser principal behavior.
- Make Escape exit expanded mode before closing the drawer.

## Testing
- `npm run typecheck`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the expanded viewport toggle, ran verification, and drafted this PR description; Chris remains responsible for review and testing.