### PR TITLE
Improve frontend chat legibility

### DIFF
--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -107,7 +107,7 @@
 	max-width: var(--frontend-agent-chat-drawer-width, 420px);
 	display: flex;
 	flex-direction: column;
-	background: var(--frontend-agent-chat-drawer-bg, #f1f5f9);
+	background: var(--frontend-agent-chat-drawer-bg, #f8fafc);
 	border-left: 1px solid var(--frontend-agent-chat-border-color, #e2e8f0);
 	box-shadow: -4px 0 24px rgba(0, 0, 0, 0.2);
 	pointer-events: auto;
@@ -138,6 +138,7 @@
 	gap: var(--frontend-agent-chat-spacing-sm, 12px);
 	padding: var(--frontend-agent-chat-spacing-xs, 8px) var(--frontend-agent-chat-spacing-md, 16px);
 	border-bottom: 1px solid var(--frontend-agent-chat-border-color, #e2e8f0);
+	background: var(--frontend-agent-chat-drawer-bg, #f8fafc);
 	flex-shrink: 0;
 }
 
@@ -216,32 +217,42 @@
 	min-height: 0;
 	display: flex;
 	flex-direction: column;
+	background: var(--frontend-agent-chat-drawer-bg, #f8fafc);
 	overflow: hidden;
 }
 
 .frontend-agent-chat__body .ec-chat {
-	--ec-chat-bg: var(--frontend-agent-chat-drawer-bg, #f1f5f9);
+	--ec-chat-bg: var(--frontend-agent-chat-drawer-bg, #f8fafc);
 	--ec-chat-text: var(--frontend-agent-chat-text-primary, #1e293b);
 	--ec-chat-text-muted: var(--frontend-agent-chat-text-muted, #94a3b8);
 	--ec-chat-border: var(--frontend-agent-chat-border-color, #e2e8f0);
 	--ec-chat-user-bg: var(--frontend-agent-chat-accent, #2563eb);
 	--ec-chat-user-text: #fff;
-	--ec-chat-assistant-bg: var(--frontend-agent-chat-bg-muted, #f8fafc);
+	--ec-chat-assistant-bg: var(--frontend-agent-chat-message-bg, #fff);
 	--ec-chat-assistant-text: var(--frontend-agent-chat-text-primary, #1e293b);
-	--ec-chat-input-bg: var(--frontend-agent-chat-bg-muted, #f8fafc);
+	--ec-chat-input-bg: var(--frontend-agent-chat-input-bg, #fff);
 	--ec-chat-input-border: var(--frontend-agent-chat-border-color, #e2e8f0);
 	--ec-chat-input-focus-border: var(--frontend-agent-chat-accent, #2563eb);
 	--ec-chat-send-bg: var(--frontend-agent-chat-accent, #2563eb);
 	--ec-chat-send-text: #fff;
-	--ec-chat-tool-bg: var(--frontend-agent-chat-bg-muted, #f8fafc);
+	--ec-chat-tool-bg: var(--frontend-agent-chat-message-bg, #fff);
 	--ec-chat-tool-border: var(--frontend-agent-chat-border-color, #e2e8f0);
 	--ec-chat-session-hover-bg: var(--frontend-agent-chat-border-color, #e2e8f0);
 	--ec-chat-font-family: var(--frontend-agent-chat-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+	--ec-chat-font-size: var(--frontend-agent-chat-font-size, 15px);
 	--ec-chat-border-radius: 0;
 
+	background: var(--ec-chat-bg);
 	height: 100%;
 	min-height: 0;
 	border-radius: 0;
+}
+
+.frontend-agent-chat__body .ec-chat-messages,
+.frontend-agent-chat__body .ec-chat-input-area,
+.frontend-agent-chat__body .ec-chat-session-switcher,
+.frontend-agent-chat__body .ec-chat-session-switcher__panel {
+	background: var(--ec-chat-bg);
 }
 
 .frontend-agent-chat__persistence {


### PR DESCRIPTION
## Summary
- Raises the embedded chat default font size from 14px to 15px via the frontend wrapper theme variables.
- Makes the drawer, header, body, chat, message list, input area, and session switcher surfaces explicitly opaque.
- Keeps the theme override points available through CSS custom properties.

## Testing
- `npm run typecheck`
- `npm run build`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the CSS surface/font-size tweak and ran focused verification; Chris to review and test before merge.
