### PR TITLE
Make frontend chat branding configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ update_option( 'frontend_agent_chat_config', [
     'agent_slug'  => 'my-agent',
     'description' => 'Your AI assistant.',
     'enabled'     => true,
+    'fab_label'   => 'Agent Chat',
+    'fab_icon'    => 'AI',
 ] );
 ```
 
@@ -25,6 +27,8 @@ update_option( 'frontend_agent_chat_config', [
 | `agent_slug` | `string` | Slug of the registered WordPress agent to connect to |
 | `description` | `string` | Shown in the empty state before the first message |
 | `enabled` | `bool` | Toggle the chat on/off for this site |
+| `fab_label` | `string` | Floating action button label |
+| `fab_icon` | `string` | Floating action button icon or short text |
 
 The config can also be overridden via the `frontend_agent_chat_config` filter.
 

--- a/inc/config.php
+++ b/inc/config.php
@@ -19,6 +19,8 @@ function frontend_agent_chat_get_config(): array {
 		'agent_slug'       => '',
 		'description'      => __( 'Your AI assistant.', 'frontend-agent-chat' ),
 		'enabled'          => false,
+		'fab_label'        => __( 'Agent Chat', 'frontend-agent-chat' ),
+		'fab_icon'         => 'AI',
 		'loading_messages' => true,
 	);
 

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -72,6 +72,8 @@ function frontend_agent_chat_enqueue() {
 		'agentsPath'       => '/frontend-agent-chat/v1/agents',
 		'agentName'        => (string) ( $agent['agent_name'] ?? $agent['label'] ?? $default_agent_slug ),
 		'agentDescription' => (string) ( $agent['agent_description'] ?? $agent['description'] ?? $config['description'] ),
+		'fabLabel'         => sanitize_text_field( (string) ( $config['fab_label'] ?? __( 'Agent Chat', 'frontend-agent-chat' ) ) ),
+		'fabIcon'          => sanitize_text_field( (string) ( $config['fab_icon'] ?? 'AI' ) ),
 		'isLoggedIn'       => is_user_logged_in(),
 	);
 

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -40,6 +40,8 @@ interface AgentChatProps {
 	agentsPath: string;
 	agentName: string;
 	agentDescription: string;
+	fabLabel?: string;
+	fabIcon?: string;
 	isLoggedIn?: boolean;
 	loadingMessages?: boolean | {
 		mode?: 'default' | 'extend' | 'override';
@@ -198,6 +200,8 @@ export default function AgentChat( {
 	agentsPath,
 	agentName,
 	agentDescription,
+	fabLabel = __( 'Agent Chat', 'frontend-agent-chat' ),
+	fabIcon = 'AI',
 	isLoggedIn = false,
 	loadingMessages = true,
 	persistenceCta,
@@ -221,7 +225,6 @@ export default function AgentChat( {
 	const activeAgentSlug = selectedAgent?.slug ?? '';
 	const activeAgentName = selectedAgent?.name ?? agentName;
 	const activeAgentDescription = selectedAgent?.description ?? agentDescription;
-	const fabLabel = __( 'Brain Chat', 'frontend-agent-chat' );
 	const agentFetch = useMemo( () => createAgentFetch( activeAgentSlug ), [ activeAgentSlug ] );
 	const open = useCallback( () => setIsOpen( true ), [] );
 	const close = useCallback( () => {
@@ -340,7 +343,7 @@ export default function AgentChat( {
 					activeAgentName
 				),
 			},
-			createElement( 'span', { className: 'frontend-agent-chat__fab-icon', 'aria-hidden': true }, '🧠' ),
+			createElement( 'span', { className: 'frontend-agent-chat__fab-icon', 'aria-hidden': true }, fabIcon ),
 			createElement( 'span', { className: 'frontend-agent-chat__fab-label' }, fabLabel ),
 			unreadCount > 0 &&
 				createElement(

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,8 @@ declare global {
 			agentsPath: string;
 			agentName: string;
 			agentDescription: string;
+			fabLabel?: string;
+			fabIcon?: string;
 			isLoggedIn?: boolean;
 			loadingMessages?: boolean | {
 				mode?: 'default' | 'extend' | 'override';
@@ -82,6 +84,8 @@ function init(): void {
 			agentsPath: config.agentsPath,
 			agentName: config.agentName,
 			agentDescription: config.agentDescription,
+			fabLabel: config.fabLabel,
+			fabIcon: config.fabIcon,
 			isLoggedIn: config.isLoggedIn ?? false,
 			loadingMessages: config.loadingMessages ?? true,
 			persistenceCta: config.persistenceCta,

--- a/tests/principal-access-smoke.php
+++ b/tests/principal-access-smoke.php
@@ -58,6 +58,10 @@ function is_multisite() {
 	return false;
 }
 
+function wp_parse_args( $args, $defaults = array() ) {
+	return array_merge( $defaults, is_array( $args ) ? $args : array() );
+}
+
 function wp_get_ability( string $name ) {
 	return new FrontendAgentChatFakeAbility( $name );
 }
@@ -82,18 +86,22 @@ function frontend_agent_chat_smoke_assert_equals( $expected, $actual, string $me
 
 echo "frontend-agent-chat-principal-access-smoke\n";
 
+$config = frontend_agent_chat_get_config();
+frontend_agent_chat_smoke_assert_equals( 'Agent Chat', $config['fab_label'] ?? '', 'frontend chat has generic default FAB label', $failures, $passes );
+frontend_agent_chat_smoke_assert_equals( 'AI', $config['fab_icon'] ?? '', 'frontend chat has generic default FAB icon', $failures, $passes );
+
 $GLOBALS['frontend_agent_chat_smoke_calls']   = array();
 $GLOBALS['frontend_agent_chat_smoke_allowed'] = true;
 $GLOBALS['frontend_agent_chat_smoke_agents']  = array(
 	array(
-		'slug'        => 'wiki-brain',
-		'label'       => 'Wiki Brain',
-		'description' => 'Answers from the wiki.',
+		'slug'        => 'demo-agent',
+		'label'       => 'Demo Agent',
+		'description' => 'Answers user questions.',
 	),
 );
 
 $agents = frontend_agent_chat_list_accessible_agents();
-frontend_agent_chat_smoke_assert_equals( 'wiki-brain', $agents[0]['agent_slug'] ?? '', 'accessible agents normalize from Agents API ability', $failures, $passes );
+frontend_agent_chat_smoke_assert_equals( 'demo-agent', $agents[0]['agent_slug'] ?? '', 'accessible agents normalize from Agents API ability', $failures, $passes );
 frontend_agent_chat_smoke_assert_equals( true, frontend_agent_chat_user_can_see( $agents[0] ), 'visibility delegates to Agents API access without requiring a WP login', $failures, $passes );
 
 $GLOBALS['frontend_agent_chat_smoke_allowed'] = false;

--- a/tests/tool-transcript-message-filter-smoke.php
+++ b/tests/tool-transcript-message-filter-smoke.php
@@ -34,7 +34,7 @@ $messages = frontend_agent_chat_session_messages(
 			array(
 				'role'    => 'assistant',
 				'type'    => 'tool_call',
-				'content' => 'AI ACTION (Turn 1): Executing Wiki Brain List.',
+				'content' => 'AI ACTION (Turn 1): Executing Data Lookup.',
 			),
 			array(
 				'role'    => 'user',


### PR DESCRIPTION
## Summary
- Replace hardcoded Brain Chat FAB branding with generic configurable `fab_label` and `fab_icon` options.
- Pass FAB branding through the localized frontend config into the React chat component.
- Clean generic smoke fixtures so frontend-agent-chat no longer references Intelligence/wiki brain concepts.

## Testing
- `npm run typecheck`
- `npm run build`
- `php tests/principal-access-smoke.php`
- `php tests/tool-transcript-message-filter-smoke.php`
- `php -l inc/config.php`
- `php -l inc/enqueue.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, updated smoke fixtures/docs, and ran verification commands for Chris to review.