### PR TITLE
Load default chat session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "^0.12.1"
+				"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.2"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2656,9 +2656,8 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.12.1.tgz",
-			"integrity": "sha512-c5K37JjanEYhVa9DItSmEkD8GTesGp3hTKOojRx0Xd9KoIxgsJABGSxCGj+TSfTql9ocIsiRTHv6p4wpHuSgGQ==",
+			"version": "0.12.2",
+			"resolved": "git+https://github.com/Extra-Chill/chat.git#658614dc4ef270be8d4672d67213a705e51b9a90",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "^0.12.1"
+		"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.2"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",


### PR DESCRIPTION
## Summary
- Update `@extrachill/chat` to the `v0.12.2` tag containing the default-session hydration fix.
- Ensure the frontend chat UI loads the only/default conversation instead of merely showing it selected in the dropdown.

## Testing
- `npm run typecheck`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the session loading bug, shipped the upstream chat package fix, updated the frontend dependency, and ran verification commands for Chris to review.