### PR TITLE
Use selectable chat theme colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.2"
+				"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.3"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2656,8 +2656,8 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.12.2",
-			"resolved": "git+https://github.com/Extra-Chill/chat.git#658614dc4ef270be8d4672d67213a705e51b9a90",
+			"version": "0.12.3",
+			"resolved": "git+https://github.com/Extra-Chill/chat.git#5fc53dcff3b486e08bc6d2b7c441675ba43617e2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.2"
+		"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.3"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",


### PR DESCRIPTION
## Summary
- Update `@extrachill/chat` to `v0.12.3` with generic select color theme tokens.
- Keep the session switcher extensible via CSS custom properties instead of hardcoded product styles.
- Fix conversation dropdown contrast in themed containers.

## Testing
- `npm run typecheck`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the session dropdown contrast issue, added generic upstream select theme tokens, updated the frontend dependency, and ran verification commands for Chris to review.