### PR TITLE
Update chat UI styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.3"
+				"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.4"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2656,8 +2656,8 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.12.3",
-			"resolved": "git+https://github.com/Extra-Chill/chat.git#5fc53dcff3b486e08bc6d2b7c441675ba43617e2",
+			"version": "0.12.4",
+			"resolved": "git+https://github.com/Extra-Chill/chat.git#e91e9682ba65b2d0911305b1cf6115762ccc210f",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.3"
+		"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.4"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",


### PR DESCRIPTION
## Summary
- Update `@extrachill/chat` to `v0.12.4`.
- Includes generic select color theme tokens from `v0.12.3`.
- Includes typing indicator clipping fixes and generic typing theme tokens from `v0.12.4`.

## Testing
- `npm run typecheck`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated the frontend dependency to the upstream chat UI fixes and ran verification commands for Chris to review.