### PR TITLE
Use extensible SVG expand icon

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -16,12 +16,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function frontend_agent_chat_get_config(): array {
 	$defaults = array(
-		'agent_slug'       => '',
-		'description'      => __( 'Your AI assistant.', 'frontend-agent-chat' ),
-		'enabled'          => false,
-		'fab_label'        => __( 'Agent Chat', 'frontend-agent-chat' ),
-		'fab_icon'         => 'AI',
-		'loading_messages' => true,
+		'agent_slug'           => '',
+		'description'          => __( 'Your AI assistant.', 'frontend-agent-chat' ),
+		'enabled'              => false,
+		'fab_label'            => __( 'Agent Chat', 'frontend-agent-chat' ),
+		'fab_icon'             => 'AI',
+		'expand_icon_path'     => '',
+		'collapse_icon_path'   => '',
+		'expand_icon_view_box' => '0 0 24 24',
+		'loading_messages'     => true,
 	);
 
 	$saved = get_option( 'frontend_agent_chat_config', array() );

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -11,6 +11,40 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Sanitize SVG path data for icon configuration.
+ *
+ * Consumers may override icon shapes through frontend_agent_chat_config, but
+ * the widget still owns the SVG element. This keeps the extension point narrow
+ * and avoids passing raw markup to the browser.
+ *
+ * @param mixed $path SVG path data.
+ * @return string Sanitized path data, or empty string when invalid.
+ */
+function frontend_agent_chat_sanitize_svg_path( $path ): string {
+	$path = trim( (string) $path );
+	if ( '' === $path || ! preg_match( '/^[MmZzLlHhVvCcSsQqTtAa0-9.,\-\s]+$/', $path ) ) {
+		return '';
+	}
+
+	return $path;
+}
+
+/**
+ * Sanitize SVG viewBox data for icon configuration.
+ *
+ * @param mixed $view_box SVG viewBox data.
+ * @return string Sanitized viewBox data.
+ */
+function frontend_agent_chat_sanitize_svg_view_box( $view_box ): string {
+	$view_box = trim( (string) $view_box );
+	if ( ! preg_match( '/^-?\d+(?:\.\d+)?\s+-?\d+(?:\.\d+)?\s+\d+(?:\.\d+)?\s+\d+(?:\.\d+)?$/', $view_box ) ) {
+		return '0 0 24 24';
+	}
+
+	return $view_box;
+}
+
+/**
  * Enqueue the frontend chat script and styles.
  *
  * Fires on wp_enqueue_scripts so the assets load on every frontend page.
@@ -66,15 +100,18 @@ function frontend_agent_chat_enqueue() {
 	}
 
 	$js_config = array(
-		'agentSlug'        => (string) ( $agent['agent_slug'] ?? $default_agent_slug ),
-		'basePath'         => '/frontend-agent-chat/v1/chat',
-		'bootstrapPath'    => '/frontend-agent-chat/v1/bootstrap',
-		'agentsPath'       => '/frontend-agent-chat/v1/agents',
-		'agentName'        => (string) ( $agent['agent_name'] ?? $agent['label'] ?? $default_agent_slug ),
-		'agentDescription' => (string) ( $agent['agent_description'] ?? $agent['description'] ?? $config['description'] ),
-		'fabLabel'         => sanitize_text_field( (string) ( $config['fab_label'] ?? __( 'Agent Chat', 'frontend-agent-chat' ) ) ),
-		'fabIcon'          => sanitize_text_field( (string) ( $config['fab_icon'] ?? 'AI' ) ),
-		'isLoggedIn'       => is_user_logged_in(),
+		'agentSlug'         => (string) ( $agent['agent_slug'] ?? $default_agent_slug ),
+		'basePath'          => '/frontend-agent-chat/v1/chat',
+		'bootstrapPath'     => '/frontend-agent-chat/v1/bootstrap',
+		'agentsPath'        => '/frontend-agent-chat/v1/agents',
+		'agentName'         => (string) ( $agent['agent_name'] ?? $agent['label'] ?? $default_agent_slug ),
+		'agentDescription'  => (string) ( $agent['agent_description'] ?? $agent['description'] ?? $config['description'] ),
+		'fabLabel'          => sanitize_text_field( (string) ( $config['fab_label'] ?? __( 'Agent Chat', 'frontend-agent-chat' ) ) ),
+		'fabIcon'           => sanitize_text_field( (string) ( $config['fab_icon'] ?? 'AI' ) ),
+		'expandIconPath'    => frontend_agent_chat_sanitize_svg_path( $config['expand_icon_path'] ?? '' ),
+		'collapseIconPath'  => frontend_agent_chat_sanitize_svg_path( $config['collapse_icon_path'] ?? '' ),
+		'expandIconViewBox' => frontend_agent_chat_sanitize_svg_view_box( $config['expand_icon_view_box'] ?? '0 0 24 24' ),
+		'isLoggedIn'        => is_user_logged_in(),
 	);
 
 	/**

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -42,6 +42,9 @@ interface AgentChatProps {
 	agentDescription: string;
 	fabLabel?: string;
 	fabIcon?: string;
+	expandIconPath?: string;
+	collapseIconPath?: string;
+	expandIconViewBox?: string;
 	isLoggedIn?: boolean;
 	loadingMessages?: boolean | {
 		mode?: 'default' | 'extend' | 'override';
@@ -91,6 +94,9 @@ interface AgentsResponse {
 		agents?: AgentSummary[];
 	};
 }
+
+const DEFAULT_EXPAND_ICON_PATH = 'M3 8V3h5M21 8V3h-5M3 16v5h5M21 16v5h-5';
+const DEFAULT_COLLAPSE_ICON_PATH = 'M8 3v5H3M16 3v5h5M8 21v-5H3M16 21v-5h5';
 
 /**
  * Parse a tool result into DiffData for DiffCard rendering.
@@ -193,16 +199,12 @@ function renderDiffCard( group: ToolGroup ): ReactNode {
 	} );
 }
 
-function renderExpandIcon( isExpanded: boolean ): ReactNode {
-	const path = isExpanded
-		? 'M8 3v5H3M16 3v5h5M8 21v-5H3M16 21v-5h5'
-		: 'M3 8V3h5M21 8V3h-5M3 16v5h5M21 16v5h-5';
-
+function renderExpandIcon( path: string, viewBox: string ): ReactNode {
 	return createElement(
 		'svg',
 		{
 			className: 'frontend-agent-chat__expand-icon',
-			viewBox: '0 0 24 24',
+			viewBox,
 			width: 18,
 			height: 18,
 			'aria-hidden': true,
@@ -228,6 +230,9 @@ export default function AgentChat( {
 	agentDescription,
 	fabLabel = __( 'Agent Chat', 'frontend-agent-chat' ),
 	fabIcon = 'AI',
+	expandIconPath,
+	collapseIconPath,
+	expandIconViewBox = '0 0 24 24',
 	isLoggedIn = false,
 	loadingMessages = true,
 	persistenceCta,
@@ -353,6 +358,9 @@ export default function AgentChat( {
 	const expandedButtonLabel = isExpanded
 		? __( 'Exit expanded chat view', 'frontend-agent-chat' )
 		: __( 'Expand chat to viewport', 'frontend-agent-chat' );
+	const expandButtonIconPath = isExpanded
+		? ( collapseIconPath || DEFAULT_COLLAPSE_ICON_PATH )
+		: ( expandIconPath || DEFAULT_EXPAND_ICON_PATH );
 
 	return createElement(
 		'div',
@@ -421,7 +429,7 @@ export default function AgentChat( {
 							'aria-label': expandedButtonLabel,
 							'aria-pressed': isExpanded,
 						},
-						renderExpandIcon( isExpanded )
+						renderExpandIcon( expandButtonIconPath, expandIconViewBox )
 					),
 					createElement(
 						'button',

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -193,6 +193,32 @@ function renderDiffCard( group: ToolGroup ): ReactNode {
 	} );
 }
 
+function renderExpandIcon( isExpanded: boolean ): ReactNode {
+	const path = isExpanded
+		? 'M8 3v5H3M16 3v5h5M8 21v-5H3M16 21v-5h5'
+		: 'M3 8V3h5M21 8V3h-5M3 16v5h5M21 16v5h-5';
+
+	return createElement(
+		'svg',
+		{
+			className: 'frontend-agent-chat__expand-icon',
+			viewBox: '0 0 24 24',
+			width: 18,
+			height: 18,
+			'aria-hidden': true,
+			focusable: false,
+		},
+		createElement( 'path', {
+			d: path,
+			fill: 'none',
+			stroke: 'currentColor',
+			strokeLinecap: 'round',
+			strokeLinejoin: 'round',
+			strokeWidth: 2,
+		} )
+	);
+}
+
 export default function AgentChat( {
 	agentSlug,
 	basePath,
@@ -395,7 +421,7 @@ export default function AgentChat( {
 							'aria-label': expandedButtonLabel,
 							'aria-pressed': isExpanded,
 						},
-						isExpanded ? '\u2199' : '\u2197'
+						renderExpandIcon( isExpanded )
 					),
 					createElement(
 						'button',

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -212,6 +212,11 @@
 	outline-offset: 2px;
 }
 
+.frontend-agent-chat__expand-icon {
+	display: block;
+	flex-shrink: 0;
+}
+
 .frontend-agent-chat__body {
 	flex: 1;
 	min-height: 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,9 @@ declare global {
 			agentDescription: string;
 			fabLabel?: string;
 			fabIcon?: string;
+			expandIconPath?: string;
+			collapseIconPath?: string;
+			expandIconViewBox?: string;
 			isLoggedIn?: boolean;
 			loadingMessages?: boolean | {
 				mode?: 'default' | 'extend' | 'override';
@@ -86,6 +89,9 @@ function init(): void {
 			agentDescription: config.agentDescription,
 			fabLabel: config.fabLabel,
 			fabIcon: config.fabIcon,
+			expandIconPath: config.expandIconPath,
+			collapseIconPath: config.collapseIconPath,
+			expandIconViewBox: config.expandIconViewBox,
 			isLoggedIn: config.isLoggedIn ?? false,
 			loadingMessages: config.loadingMessages ?? true,
 			persistenceCta: config.persistenceCta,


### PR DESCRIPTION
## Summary
- Replace expand/collapse arrow text with self-contained inline SVG icons.
- Add safe config fields for consumer overrides: `expand_icon_path`, `collapse_icon_path`, and `expand_icon_view_box`.
- Keep rendering owned by the widget and theme styling through `currentColor`.

## Testing
- `npm run typecheck`
- `npm run build`
- `php -l inc/enqueue.php`
- `php -l inc/config.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-frontend-chat@fix-expand-inline-svg-icon --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Replaced the expand glyph with inline SVG defaults, added a safe consumer override surface, and ran verification commands for Chris to review.