### PR TITLE
Fix fullscreen chat admin bar offset

### DIFF
--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -83,18 +83,18 @@
 	pointer-events: none;
 }
 
-.admin-bar .frontend-agent-chat__drawer {
-	top: var(--wp-admin--admin-bar--height, 32px);
-}
-
-.admin-bar .frontend-agent-chat__drawer.is-expanded {
-	top: 0;
+.admin-bar .frontend-agent-chat {
+	--frontend-agent-chat-admin-bar-offset: var(--wp-admin--admin-bar--height, 32px);
 }
 
 @media (max-width: 782px) {
-	.admin-bar .frontend-agent-chat__drawer {
-		top: 0;
+	.admin-bar .frontend-agent-chat {
+		--frontend-agent-chat-admin-bar-offset: var(--wp-admin--admin-bar--height, 46px);
 	}
+}
+
+.admin-bar .frontend-agent-chat__drawer {
+	top: var(--frontend-agent-chat-admin-bar-offset);
 }
 
 .frontend-agent-chat__drawer {


### PR DESCRIPTION
## Summary
- Keep the WordPress admin bar offset applied to the chat drawer in expanded mode.
- Use the WordPress admin bar height variable for desktop and mobile offsets.

## Testing
- npm run typecheck
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the CSS fix, ran verification, and prepared this PR. Chris reviewed the requested behavior and package boundary.