### PR TITLE
Allow browser chat session listing

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -302,6 +302,51 @@ function frontend_agent_chat_add_browser_principal_input( array $input ): array 
 }
 
 /**
+ * Allow anonymous browser principals to use their own chat-session store.
+ *
+ * Agents API's generic session abilities default to logged-in users. The
+ * frontend widget scopes anonymous sessions to a signed browser principal, so
+ * allow only inputs whose owner fields match the current browser cookie and an
+ * agent the current visitor may see.
+ *
+ * @param bool  $allowed Existing permission decision.
+ * @param array $input   Ability input.
+ * @return bool Whether the ability may run.
+ */
+function frontend_agent_chat_allow_browser_conversation_sessions( bool $allowed, array $input ): bool {
+	if ( $allowed || is_user_logged_in() ) {
+		return $allowed;
+	}
+
+	$principal = frontend_agent_chat_get_browser_principal();
+	if ( ! $principal ) {
+		return false;
+	}
+
+	$input_principal = is_array( $input['principal'] ?? null ) ? $input['principal'] : array();
+	$transcript_owner = is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : array();
+	if (
+		'browser' !== (string) ( $input_principal['owner_type'] ?? '' ) ||
+		$principal['id'] !== (string) ( $input_principal['owner_key'] ?? '' ) ||
+		'browser' !== (string) ( $transcript_owner['type'] ?? '' ) ||
+		$principal['id'] !== (string) ( $transcript_owner['key'] ?? '' )
+	) {
+		return false;
+	}
+
+	$agent_slug = sanitize_title( (string) ( $input['agent'] ?? $input_principal['effective_agent_id'] ?? '' ) );
+	if ( '' === $agent_slug ) {
+		return false;
+	}
+
+	return frontend_agent_chat_user_can_see( frontend_agent_chat_resolve_agent( $agent_slug ) );
+}
+
+if ( function_exists( 'add_filter' ) ) {
+	add_filter( 'agents_conversation_sessions_permission', 'frontend_agent_chat_allow_browser_conversation_sessions', 10, 2 );
+}
+
+/**
  * Normalize an Agents API descriptor for frontend chat use.
  *
  * @param array $agent Raw agent descriptor.

--- a/tests/principal-access-smoke.php
+++ b/tests/principal-access-smoke.php
@@ -10,6 +10,9 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
+if ( ! defined( 'FRONTEND_AGENT_CHAT_BROWSER_COOKIE' ) ) {
+	define( 'FRONTEND_AGENT_CHAT_BROWSER_COOKIE', 'frontend_agent_chat_browser' );
+}
 
 class WP_Agent_Access_Grant {
 	public const ROLE_VIEWER = 'viewer';
@@ -70,6 +73,19 @@ function is_wp_error( $value ) {
 	return false;
 }
 
+function is_user_logged_in() {
+	return false;
+}
+
+function wp_unslash( $value ) {
+	return $value;
+}
+
+function wp_salt( $scheme = 'auth' ) {
+	unset( $scheme );
+	return 'frontend-agent-chat-smoke-salt';
+}
+
 require_once dirname( __DIR__ ) . '/inc/config.php';
 
 $failures = array();
@@ -106,6 +122,18 @@ frontend_agent_chat_smoke_assert_equals( true, frontend_agent_chat_user_can_see(
 
 $GLOBALS['frontend_agent_chat_smoke_allowed'] = false;
 frontend_agent_chat_smoke_assert_equals( false, frontend_agent_chat_user_can_see( $agents[0] ), 'visibility fails closed when Agents API denies the current principal', $failures, $passes );
+
+$_COOKIE[ FRONTEND_AGENT_CHAT_BROWSER_COOKIE ] = str_repeat( 'a', 64 );
+$GLOBALS['frontend_agent_chat_smoke_allowed']  = true;
+$list_input                                    = frontend_agent_chat_add_browser_principal_input( array( 'agent' => 'demo-agent' ) );
+frontend_agent_chat_smoke_assert_equals( true, frontend_agent_chat_allow_browser_conversation_sessions( false, $list_input ), 'browser principal may list its own conversation sessions', $failures, $passes );
+
+$tampered_input                                    = $list_input;
+$tampered_input['transcript_owner']['key']         = 'browser:tampered';
+frontend_agent_chat_smoke_assert_equals( false, frontend_agent_chat_allow_browser_conversation_sessions( false, $tampered_input ), 'browser principal cannot list another browser owner', $failures, $passes );
+
+$GLOBALS['frontend_agent_chat_smoke_allowed'] = false;
+frontend_agent_chat_smoke_assert_equals( false, frontend_agent_chat_allow_browser_conversation_sessions( false, $list_input ), 'browser session ability permission still requires agent access', $failures, $passes );
 
 $GLOBALS['frontend_agent_chat_smoke_agents'] = array();
 frontend_agent_chat_smoke_assert_equals( array(), frontend_agent_chat_list_accessible_agents(), 'no accessible principal grants means no agents', $failures, $passes );


### PR DESCRIPTION
## Summary
- Allows anonymous frontend chat browser principals to use Agents API conversation-session abilities for their own browser-owned transcripts.
- Keeps permission narrow by requiring matching browser principal/owner fields and access to the requested agent.
- Adds smoke coverage for allowed, tampered-owner, and denied-agent cases.

## Testing
- `php -l inc/config.php`
- `php -l inc/rest.php`
- `php tests/principal-access-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the browser session-listing permission failure, drafted the code/test changes, and ran targeted local validation. Chris remains responsible for review and merge.