### PR TITLE
fix(fab): omit icon slot entirely when fab_icon is empty

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -377,7 +377,8 @@ export default function AgentChat( {
 					activeAgentName
 				),
 			},
-			createElement( 'span', { className: 'frontend-agent-chat__fab-icon', 'aria-hidden': true }, fabIcon ),
+			'' !== fabIcon &&
+				createElement( 'span', { className: 'frontend-agent-chat__fab-icon', 'aria-hidden': true }, fabIcon ),
 			createElement( 'span', { className: 'frontend-agent-chat__fab-label' }, fabLabel ),
 			unreadCount > 0 &&
 				createElement(


### PR DESCRIPTION
The FAB previously rendered an empty `<span class="frontend-agent-chat__fab-icon">` even when a consumer set `fab_icon` to an empty string via the `frontend_agent_chat_config` filter. The empty span still occupied layout (flex gap + aria-hidden node).

Render the icon span only when `fab_icon` is a non-empty string. The default `'AI'` icon still ships for un-configured installs; consumers who want no icon now get no slot.