### PR TITLE
fix(rest): preserve multimodal content + attachments on session reload

### DIFF
--- a/inc/rest.php
+++ b/inc/rest.php
@@ -597,8 +597,14 @@ function frontend_agent_chat_normalize_result_messages( array $result, string $u
 /**
  * Extract chat messages from a session or runtime result.
  *
+ * Normalizes both classic single-string content and multimodal content
+ * (an array of text/image parts produced by user image uploads) into the
+ * @extrachill/chat wire shape: `content` is always a plain string, and
+ * media is surfaced separately via `metadata.attachments` so the frontend
+ * normalizer can render image previews on session reload.
+ *
  * @param array $source Session or runtime result.
- * @return array<int,array{role:string,content:string}>
+ * @return array<int,array{role:string,content:string,metadata?:array}>
  */
 function frontend_agent_chat_session_messages( array $source ): array {
 	$messages = array();
@@ -616,13 +622,57 @@ function frontend_agent_chat_session_messages( array $source ): array {
 			continue;
 		}
 
-		$messages[] = array(
+		$normalized = array(
 			'role'    => $role,
-			'content' => (string) $message['content'],
+			'content' => frontend_agent_chat_flatten_message_content( $message['content'] ),
 		);
+
+		// Pass metadata through so the frontend normalizer can surface
+		// attachments (user image uploads, tool-produced media) on session
+		// reload. Without this, multimodal messages would render text-only.
+		if ( isset( $message['metadata'] ) && is_array( $message['metadata'] ) ) {
+			$normalized['metadata'] = $message['metadata'];
+		}
+
+		$messages[] = $normalized;
 	}
 
 	return $messages;
+}
+
+/**
+ * Flatten a message content payload into a plain string for the wire.
+ *
+ * Multimodal messages store content as an array of `{type, text}` and
+ * `{type, image_url}` parts (the canonical agents-api.message v1 shape).
+ * Concatenate the text parts; image parts are surfaced separately via
+ * `metadata.attachments` and don't need to appear in `content`.
+ *
+ * @param mixed $content Raw content (string or array of parts).
+ * @return string
+ */
+function frontend_agent_chat_flatten_message_content( $content ): string {
+	if ( is_string( $content ) ) {
+		return $content;
+	}
+
+	if ( ! is_array( $content ) ) {
+		return '';
+	}
+
+	$texts = array();
+	foreach ( $content as $part ) {
+		if ( ! is_array( $part ) ) {
+			continue;
+		}
+
+		$type = (string) ( $part['type'] ?? '' );
+		if ( 'text' === $type && isset( $part['text'] ) && is_string( $part['text'] ) ) {
+			$texts[] = $part['text'];
+		}
+	}
+
+	return implode( "\n\n", $texts );
 }
 
 /**


### PR DESCRIPTION
## Problem

Sessions that include image-upload turns are mangled on reload:

- Multimodal message text shows up as the literal string `"Array"` in chat history
- Session list titles read `"Array"` for any session whose first user message included an image (since `wp_html_excerpt('Array', 60)` is just `'Array'`)
- `PHP Warning: Array to string conversion in inc/rest.php on line 621` fires on every session GET / chat-list endpoint hit for any session with a multimodal turn
- Image previews disappear on reload even though the upload succeeded and `metadata.attachments` was stored correctly in the session payload

The user experience is that an image upload looks like it "broke" the chat — text vanishes, image preview vanishes — when the underlying upload + storage are actually fine.

## Root cause

`frontend_agent_chat_session_messages()` (`inc/rest.php:603`) flattens `$message['content']` with a bare `(string)` cast.

For classic single-string messages this works. For multimodal user messages produced by the `mediaUploadFn` flow, `content` is the canonical `agents-api.message v1` shape:

```json
{
  "role": "user",
  "type": "multimodal_part",
  "content": [
    { "type": "text", "text": "Can you add this photo?" },
    { "type": "image_url", "image_url": { "url": "https://.../IMG_4877.jpeg" } }
  ],
  "metadata": {
    "attachments": [
      { "url": "https://.../IMG_4877.jpeg", "mime_type": "image/jpeg", "media_id": 29 }
    ]
  }
}
```

The `(string)` cast on an array yields `"Array"` and emits the PHP warning. The function also strips `metadata` from the wire output, so even though attachments are stored, the `@extrachill/chat` normalizer (`normalizer.ts:178 normalizeAttachments`) has nothing to work with — it reads `raw.metadata.attachments` to rebuild `MediaAttachment` entries.

## Fix

Two small changes inside `frontend_agent_chat_session_messages()`:

1. **Add `frontend_agent_chat_flatten_message_content()`** which handles both classic strings and the multimodal-parts array. Concatenates the `text` parts with double newlines; `image_url` parts are dropped because attachments are surfaced separately via `metadata.attachments`.
2. **Pass `metadata` through to the wire output** so the frontend normalizer can rebuild `MediaAttachment` entries on reload.

The `ChatMessage` type in `@extrachill/chat/types/message.ts` already documents this exact shape: `content: string` + `attachments?: MediaAttachment[]`, derived from `metadata.attachments` server-side.

## Verification

Tested end-to-end against a real production session with 3 multimodal turns:

```
Total normalized: 70
msg 10 [user]: content='https://www.martinsbbqjoint.com/charleston?utm_source=gmb&...'  attachments=1
   attachment[0].url: https://.../IMG_4877.jpeg
msg 20 [user]: content='Can you add this photo to the submission of martins'        attachments=1
   attachment[0].url: https://.../IMG_4877-1.jpeg
msg 32 [user]: content='Will this work'                                              attachments=1
   attachment[0].url: https://.../image-1.jpg

messages with attachments: 3 (expected: 3)
messages with leaked 'Array' content: 0 (expected: 0)
```

After deploy:
- PHP warnings stop firing
- Multimodal messages show their actual text content on reload
- Image previews rebuild correctly via the existing frontend normalizer
- Session list titles read the user's actual first message text instead of `"Array"`

## Versioning

Patch bump. Handled by homeboy release at merge time.