### PR TITLE
Support SVG FAB icons

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -21,6 +21,8 @@ function frontend_agent_chat_get_config(): array {
 		'enabled'              => false,
 		'fab_label'            => __( 'Agent Chat', 'frontend-agent-chat' ),
 		'fab_icon'             => 'AI',
+		'fab_icon_path'        => '',
+		'fab_icon_view_box'    => '0 0 24 24',
 		'expand_icon_path'     => '',
 		'collapse_icon_path'   => '',
 		'expand_icon_view_box' => '0 0 24 24',

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -108,6 +108,8 @@ function frontend_agent_chat_enqueue() {
 		'agentDescription'  => (string) ( $agent['agent_description'] ?? $agent['description'] ?? $config['description'] ),
 		'fabLabel'          => sanitize_text_field( (string) ( $config['fab_label'] ?? __( 'Agent Chat', 'frontend-agent-chat' ) ) ),
 		'fabIcon'           => sanitize_text_field( (string) ( $config['fab_icon'] ?? 'AI' ) ),
+		'fabIconPath'       => frontend_agent_chat_sanitize_svg_path( $config['fab_icon_path'] ?? '' ),
+		'fabIconViewBox'    => frontend_agent_chat_sanitize_svg_view_box( $config['fab_icon_view_box'] ?? '0 0 24 24' ),
 		'expandIconPath'    => frontend_agent_chat_sanitize_svg_path( $config['expand_icon_path'] ?? '' ),
 		'collapseIconPath'  => frontend_agent_chat_sanitize_svg_path( $config['collapse_icon_path'] ?? '' ),
 		'expandIconViewBox' => frontend_agent_chat_sanitize_svg_view_box( $config['expand_icon_view_box'] ?? '0 0 24 24' ),

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -42,6 +42,8 @@ interface AgentChatProps {
 	agentDescription: string;
 	fabLabel?: string;
 	fabIcon?: string;
+	fabIconPath?: string;
+	fabIconViewBox?: string;
 	expandIconPath?: string;
 	collapseIconPath?: string;
 	expandIconViewBox?: string;
@@ -221,6 +223,27 @@ function renderExpandIcon( path: string, viewBox: string ): ReactNode {
 	);
 }
 
+function renderFabIcon( icon: string, path: string, viewBox: string ): ReactNode {
+	if ( path ) {
+		return createElement(
+			'svg',
+			{
+				className: 'frontend-agent-chat__fab-svg',
+				viewBox,
+				width: 22,
+				height: 22,
+				'aria-hidden': true,
+				focusable: false,
+			},
+			createElement( 'path', { d: path, fill: 'currentColor' } )
+		);
+	}
+
+	return '' !== icon
+		? createElement( 'span', { className: 'frontend-agent-chat__fab-icon', 'aria-hidden': true }, icon )
+		: null;
+}
+
 export default function AgentChat( {
 	agentSlug,
 	basePath,
@@ -230,6 +253,8 @@ export default function AgentChat( {
 	agentDescription,
 	fabLabel = __( 'Agent Chat', 'frontend-agent-chat' ),
 	fabIcon = 'AI',
+	fabIconPath = '',
+	fabIconViewBox = '0 0 24 24',
 	expandIconPath,
 	collapseIconPath,
 	expandIconViewBox = '0 0 24 24',
@@ -377,8 +402,7 @@ export default function AgentChat( {
 					activeAgentName
 				),
 			},
-			'' !== fabIcon &&
-				createElement( 'span', { className: 'frontend-agent-chat__fab-icon', 'aria-hidden': true }, fabIcon ),
+			renderFabIcon( fabIcon, fabIconPath, fabIconViewBox ),
 			createElement( 'span', { className: 'frontend-agent-chat__fab-label' }, fabLabel ),
 			unreadCount > 0 &&
 				createElement(

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -43,6 +43,11 @@
 	line-height: 1;
 }
 
+.frontend-agent-chat__fab-svg {
+	display: block;
+	flex: 0 0 auto;
+}
+
 .frontend-agent-chat__fab-label {
 	display: inline-flex;
 	line-height: 1;


### PR DESCRIPTION
## Summary
- add generic `fab_icon_path` and `fab_icon_view_box` config fields
- sanitize FAB SVG path/viewBox through the existing narrow icon sanitizers
- render an SVG FAB icon when a path is configured, preserving text fallback

## Verification
- npm run build
- php -l inc/config.php
- php -l inc/enqueue.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic SVG FAB icon extension and ran local build/syntax checks; Chris remains responsible for review and testing.