### PR TITLE
Support inline chat layout

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -27,6 +27,7 @@ function frontend_agent_chat_get_config(): array {
 		'collapse_icon_path'   => '',
 		'expand_icon_view_box' => '0 0 24 24',
 		'loading_messages'     => true,
+		'layout'               => 'floating',
 	);
 
 	$saved = get_option( 'frontend_agent_chat_config', array() );

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -113,6 +113,7 @@ function frontend_agent_chat_enqueue() {
 		'expandIconPath'    => frontend_agent_chat_sanitize_svg_path( $config['expand_icon_path'] ?? '' ),
 		'collapseIconPath'  => frontend_agent_chat_sanitize_svg_path( $config['collapse_icon_path'] ?? '' ),
 		'expandIconViewBox' => frontend_agent_chat_sanitize_svg_view_box( $config['expand_icon_view_box'] ?? '0 0 24 24' ),
+		'layout'            => 'inline' === ( $config['layout'] ?? '' ) ? 'inline' : 'floating',
 		'isLoggedIn'        => is_user_logged_in(),
 	);
 

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -47,6 +47,7 @@ interface AgentChatProps {
 	expandIconPath?: string;
 	collapseIconPath?: string;
 	expandIconViewBox?: string;
+	layout?: 'floating' | 'inline';
 	isLoggedIn?: boolean;
 	loadingMessages?: boolean | {
 		mode?: 'default' | 'extend' | 'override';
@@ -258,11 +259,13 @@ export default function AgentChat( {
 	expandIconPath,
 	collapseIconPath,
 	expandIconViewBox = '0 0 24 24',
+	layout = 'floating',
 	isLoggedIn = false,
 	loadingMessages = true,
 	persistenceCta,
 }: AgentChatProps ) {
-	const [ isOpen, setIsOpen ] = useState( false );
+	const isInline = layout === 'inline';
+	const [ isOpen, setIsOpen ] = useState( isInline );
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ unreadCount, setUnreadCount ] = useState( 0 );
 	const [ browserBootstrapReady, setBrowserBootstrapReady ] = useState( isLoggedIn );
@@ -284,15 +287,26 @@ export default function AgentChat( {
 	const agentFetch = useMemo( () => createAgentFetch( activeAgentSlug ), [ activeAgentSlug ] );
 	const open = useCallback( () => setIsOpen( true ), [] );
 	const close = useCallback( () => {
+		if ( isInline ) {
+			return;
+		}
+
 		setIsOpen( false );
 		setIsExpanded( false );
-	}, [] );
+	}, [ isInline ] );
 	const toggleExpanded = useCallback( () => setIsExpanded( ( expanded ) => ! expanded ), [] );
 	const switchAgent = useCallback( ( event: ChangeEvent< HTMLSelectElement > ) => {
 		const nextAgentSlug = event.target.value;
 		setSelectedAgentSlug( nextAgentSlug );
 		persistActiveAgent( nextAgentSlug );
 	}, [] );
+
+	useEffect( () => {
+		if ( isInline ) {
+			setIsOpen( true );
+			setIsExpanded( false );
+		}
+	}, [ isInline ] );
 
 	useEffect( () => {
 		if ( isLoggedIn ) {
@@ -354,7 +368,7 @@ export default function AgentChat( {
 	// Escape exits expanded mode first, then closes the drawer.
 	useEffect( () => {
 		function handleKeyDown( e: KeyboardEvent ) {
-			if ( e.key !== 'Escape' || ! isOpen ) {
+			if ( isInline || e.key !== 'Escape' || ! isOpen ) {
 				return;
 			}
 
@@ -367,7 +381,7 @@ export default function AgentChat( {
 		}
 		document.addEventListener( 'keydown', handleKeyDown );
 		return () => document.removeEventListener( 'keydown', handleKeyDown );
-	}, [ isExpanded, isOpen ] );
+	}, [ isExpanded, isInline, isOpen ] );
 
 	const toolRenderers = useMemo(
 		() => ( {
@@ -389,8 +403,8 @@ export default function AgentChat( {
 
 	return createElement(
 		'div',
-		{ className: 'frontend-agent-chat' },
-		createElement(
+		{ className: `frontend-agent-chat is-${ layout }` },
+		! isInline && createElement(
 			'button',
 			{
 				type: 'button',
@@ -414,13 +428,13 @@ export default function AgentChat( {
 		createElement(
 			'div',
 			{
-				className: `frontend-agent-chat__drawer${ isOpen ? ' is-open' : '' }${ isExpanded ? ' is-expanded' : '' }`,
+				className: `frontend-agent-chat__drawer${ isOpen ? ' is-open' : '' }${ isExpanded ? ' is-expanded' : '' }${ isInline ? ' is-inline' : '' }`,
 				'aria-hidden': ! isOpen,
 			},
 			createElement(
 				'div',
 				{ className: 'frontend-agent-chat__header' },
-				createElement(
+				! isInline && createElement(
 					'div',
 					{ className: 'frontend-agent-chat__agent' },
 					agents.length > 1 ? createElement(

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -11,6 +11,15 @@
 	pointer-events: none;
 }
 
+.frontend-agent-chat.is-inline {
+	position: relative;
+	z-index: auto;
+	inset: auto;
+	width: 100%;
+	height: 100%;
+	pointer-events: auto;
+}
+
 .frontend-agent-chat__fab {
 	position: fixed;
 	z-index: 9999;
@@ -134,6 +143,22 @@
 .frontend-agent-chat__drawer:not(.is-open) {
 	visibility: hidden;
 	transition: transform 0.25s ease, visibility 0s 0.25s;
+}
+
+.frontend-agent-chat__drawer.is-inline {
+	position: relative;
+	z-index: auto;
+	top: auto;
+	right: auto;
+	bottom: auto;
+	width: 100%;
+	max-width: none;
+	height: 100%;
+	border-left: none;
+	box-shadow: none;
+	transform: none;
+	transition: none;
+	visibility: visible;
 }
 
 .frontend-agent-chat__header {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,9 +36,12 @@ declare global {
 			agentDescription: string;
 			fabLabel?: string;
 			fabIcon?: string;
+			fabIconPath?: string;
+			fabIconViewBox?: string;
 			expandIconPath?: string;
 			collapseIconPath?: string;
 			expandIconViewBox?: string;
+			layout?: 'floating' | 'inline';
 			isLoggedIn?: boolean;
 			loadingMessages?: boolean | {
 				mode?: 'default' | 'extend' | 'override';
@@ -89,9 +92,12 @@ function init(): void {
 			agentDescription: config.agentDescription,
 			fabLabel: config.fabLabel,
 			fabIcon: config.fabIcon,
+			fabIconPath: config.fabIconPath,
+			fabIconViewBox: config.fabIconViewBox,
 			expandIconPath: config.expandIconPath,
 			collapseIconPath: config.collapseIconPath,
 			expandIconViewBox: config.expandIconViewBox,
+			layout: config.layout,
 			isLoggedIn: config.isLoggedIn ?? false,
 			loadingMessages: config.loadingMessages ?? true,
 			persistenceCta: config.persistenceCta,


### PR DESCRIPTION
## Summary
- add a generic frontend-agent-chat layout config with floating as the default
- support an inline layout that keeps chat mounted inside the page instead of behind a FAB/drawer
- keep the existing floating widget behavior unchanged for current consumers

## Testing
- npm run build
- npm run typecheck
- php -l inc/config.php
- php -l inc/enqueue.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the inline layout extension point and ran local build/type/PHP checks; Chris remains responsible for review and acceptance.