### PR TITLE
Dispatch chat response metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.4"
+				"@extrachill/chat": "github:Extra-Chill/chat#bacd167"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2657,7 +2657,7 @@
 		},
 		"node_modules/@extrachill/chat": {
 			"version": "0.12.4",
-			"resolved": "git+https://github.com/Extra-Chill/chat.git#e91e9682ba65b2d0911305b1cf6115762ccc210f",
+			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#bacd1677fd5508113ddf0f3e873b07d226585e27",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "git+https://github.com/Extra-Chill/chat.git#v0.12.4"
+		"@extrachill/chat": "github:Extra-Chill/chat#bacd167"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -164,6 +164,14 @@ function persistActiveAgent( agentSlug: string ): void {
 	} );
 }
 
+function dispatchResponseMetadata( metadata: Record< string, unknown > ): void {
+	window.dispatchEvent(
+		new CustomEvent( 'frontend-agent-chat:response-metadata', {
+			detail: { metadata },
+		} )
+	);
+}
+
 /**
  * Upload a file to the WordPress Media Library.
  *
@@ -511,6 +519,7 @@ export default function AgentChat( {
 						activeAgentName
 					),
 					metadata,
+					onResponseMetadata: dispatchResponseMetadata,
 					isVisible: isOpen,
 					onUnreadChange: setUnreadCount,
 					emptyState: createElement(


### PR DESCRIPTION
## Summary
- update @extrachill/chat to the metadata-capable commit
- dispatch a frontend-agent-chat:response-metadata browser event after chat responses
- allow domain plugins to react to backend response metadata without forking the chat UI

## Testing
- npm run build
- npm run typecheck
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the metadata event bridge and dependency update; Chris remains responsible for review and acceptance.