### PR TITLE
feat: render question tool cards

### DIFF
--- a/inc/rest.php
+++ b/inc/rest.php
@@ -614,6 +614,10 @@ function frontend_agent_chat_session_messages( array $source ): array {
 		}
 
 		if ( in_array( (string) ( $message['type'] ?? '' ), array( 'tool_call', 'tool_result' ), true ) ) {
+			$tool_message = frontend_agent_chat_tool_message( $message );
+			if ( null !== $tool_message ) {
+				$messages[] = $tool_message;
+			}
 			continue;
 		}
 
@@ -638,6 +642,46 @@ function frontend_agent_chat_session_messages( array $source ): array {
 	}
 
 	return $messages;
+}
+
+/**
+ * Normalize a canonical tool envelope into the chat package wire shape.
+ *
+ * @param array $message Canonical message envelope.
+ * @return array{role:string,content:string,metadata:array}|null Normalized message.
+ */
+function frontend_agent_chat_tool_message( array $message ): ?array {
+	$type = (string) ( $message['type'] ?? '' );
+	if ( ! in_array( $type, array( 'tool_call', 'tool_result' ), true ) ) {
+		return null;
+	}
+
+	$payload   = is_array( $message['payload'] ?? null ) ? $message['payload'] : array();
+	$metadata  = is_array( $message['metadata'] ?? null ) ? $message['metadata'] : array();
+	$tool_name = (string) ( $payload['tool_name'] ?? $metadata['tool_name'] ?? '' );
+	if ( '' === $tool_name ) {
+		return null;
+	}
+
+	$metadata = array_merge(
+		$metadata,
+		array(
+			'type'       => $type,
+			'tool_name'  => $tool_name,
+			'parameters' => is_array( $payload['parameters'] ?? null ) ? $payload['parameters'] : array(),
+			'tool_data'  => $payload,
+		)
+	);
+
+	if ( 'tool_result' === $type ) {
+		$metadata['success'] = (bool) ( $payload['success'] ?? $metadata['success'] ?? false );
+	}
+
+	return array(
+		'role'     => 'tool_call' === $type ? 'assistant' : 'user',
+		'content'  => frontend_agent_chat_flatten_message_content( $message['content'] ?? '' ),
+		'metadata' => $metadata,
+	);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat#eba92930d349212a94820f43251f76d2d67119d1"
+				"@extrachill/chat": "github:Extra-Chill/chat#cabadac"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2657,8 +2657,7 @@
 		},
 		"node_modules/@extrachill/chat": {
 			"version": "0.12.4",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#eba92930d349212a94820f43251f76d2d67119d1",
-			"integrity": "sha512-ZfL/Y9TBAk4klx0RgaNDNrTI4ehKxzB7Bf6Vd6XtAi7ar366hGyiBR/YZHGhFgQw/7UzBfbTUXY6Lysnq3xFig==",
+			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#cabadacbbe288ae271bce3ff7bd2ed97e3d76c39",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat#cabadac"
+				"@extrachill/chat": "github:Extra-Chill/chat#a8a4311"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2657,7 +2657,7 @@
 		},
 		"node_modules/@extrachill/chat": {
 			"version": "0.12.4",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#cabadacbbe288ae271bce3ff7bd2ed97e3d76c39",
+			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#a8a4311283a6063dabf051d69f97545fe2a39ff4",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat#eba92930d349212a94820f43251f76d2d67119d1"
+		"@extrachill/chat": "github:Extra-Chill/chat#cabadac"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat#cabadac"
+		"@extrachill/chat": "github:Extra-Chill/chat#a8a4311"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -20,10 +20,11 @@
 import {
 	Chat,
 	DiffCard,
+	QuestionCard,
 	useClientContextMetadata,
 	parseCanonicalDiffFromToolGroup,
 } from '@extrachill/chat';
-import type { ChatMessageSuggestion, ToolGroup, DiffData, FetchFn, MediaUploadFn } from '@extrachill/chat';
+import type { ChatMessageSuggestion, ToolGroup, DiffData, FetchFn, MediaUploadFn, ToolRendererContext, QuestionChoice } from '@extrachill/chat';
 import type { ChangeEvent, ReactNode } from 'react';
 
 /**
@@ -208,6 +209,83 @@ function renderDiffCard( group: ToolGroup ): ReactNode {
 		diff,
 		onAccept: ( actionId: string ) => resolvePendingAction( actionId, 'accepted' ),
 		onReject: ( actionId: string ) => resolvePendingAction( actionId, 'rejected' ),
+	} );
+}
+
+interface QuestionPayload {
+	question?: string;
+	choices?: QuestionChoice[];
+	allow_freeform?: boolean;
+	freeform_label?: string;
+	freeform_placeholder?: string;
+}
+
+function parseJsonObject( value: string ): Record< string, unknown > | null {
+	try {
+		const parsed = JSON.parse( value );
+		return parsed && typeof parsed === 'object' && ! Array.isArray( parsed )
+			? parsed as Record< string, unknown >
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function normalizeQuestionChoice( value: unknown ): QuestionChoice | null {
+	if ( ! value || typeof value !== 'object' || Array.isArray( value ) ) {
+		return null;
+	}
+
+	const choice = value as Record< string, unknown >;
+	const label = typeof choice.label === 'string' ? choice.label.trim() : '';
+	if ( ! label ) {
+		return null;
+	}
+
+	return {
+		label,
+		message: typeof choice.message === 'string' ? choice.message : undefined,
+		description: typeof choice.description === 'string' ? choice.description : undefined,
+	};
+}
+
+function questionPayloadFromToolGroup( group: ToolGroup ): QuestionPayload | null {
+	const result = group.resultMessage ? parseJsonObject( group.resultMessage.content ) : null;
+	const source = result && typeof result.result === 'object' && ! Array.isArray( result.result )
+		? result.result as Record< string, unknown >
+		: result ?? group.parameters;
+	const question = typeof source.question === 'string' ? source.question.trim() : '';
+	if ( ! question ) {
+		return null;
+	}
+
+	const choices = Array.isArray( source.choices )
+		? source.choices.map( normalizeQuestionChoice ).filter( ( choice ): choice is QuestionChoice => !! choice )
+		: [];
+
+	return {
+		question,
+		choices,
+		allow_freeform: source.allow_freeform !== false,
+		freeform_label: typeof source.freeform_label === 'string' ? source.freeform_label : undefined,
+		freeform_placeholder: typeof source.freeform_placeholder === 'string' ? source.freeform_placeholder : undefined,
+	};
+}
+
+function renderQuestionCard( group: ToolGroup, context: ToolRendererContext ): ReactNode {
+	const payload = questionPayloadFromToolGroup( group );
+	if ( ! payload ) {
+		return null;
+	}
+
+	return createElement( QuestionCard, {
+		question: payload.question ?? '',
+		choices: payload.choices,
+		allowFreeform: payload.allow_freeform,
+		freeformLabel: payload.freeform_label,
+		freeformPlaceholder: payload.freeform_placeholder,
+		disabled: context.isLoading,
+		onSubmitAnswer: context.sendMessage,
 	} );
 }
 
@@ -398,6 +476,7 @@ export default function AgentChat( {
 			edit_post_blocks: renderDiffCard,
 			replace_post_blocks: renderDiffCard,
 			insert_content: renderDiffCard,
+			studio_web_propose_questions: renderQuestionCard,
 		} ),
 		[]
 	);


### PR DESCRIPTION
## Summary
- Preserve canonical `tool_call` and `tool_result` messages in the frontend chat REST session response.
- Render Studio Web question tool calls with `QuestionCard` from `@extrachill/chat`.
- Submit selected or freeform answers through the normal chat `sendMessage` path.

## Dependency
- Depends on `@extrachill/chat` PR https://github.com/Extra-Chill/chat/pull/35.

## Testing
- `npm run typecheck`
- `npm run build`
- `php -l inc/rest.php`
- `homeboy audit --path /Users/chubes/Developer/data-machine-frontend-chat --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted REST tool-envelope preservation, frontend question-card renderer wiring, dependency update, and verification commands for Chris to review/test.
