### PR TITLE
fix: pin chat question card behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat#a8a4311"
+				"@extrachill/chat": "github:Extra-Chill/chat#b816add"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2657,7 +2657,7 @@
 		},
 		"node_modules/@extrachill/chat": {
 			"version": "0.12.4",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#a8a4311283a6063dabf051d69f97545fe2a39ff4",
+			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#b816add48d8b58eed46a895825f0df1385e13321",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat#a8a4311"
+		"@extrachill/chat": "github:Extra-Chill/chat#b816add"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",


### PR DESCRIPTION
## Summary
- Pin `@extrachill/chat` to the merged question-card behavior fixes.
- Pulls in rendering tool cards below assistant replies and hiding question cards after answer submission.

## Testing
- `npm run typecheck`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated the dependency pin and rebuilt the frontend bundle for Chris to review/test.
