### PR TITLE
fix: preserve tool call IDs

### DIFF
--- a/inc/rest.php
+++ b/inc/rest.php
@@ -666,10 +666,11 @@ function frontend_agent_chat_tool_message( array $message ): ?array {
 	$metadata = array_merge(
 		$metadata,
 		array(
-			'type'       => $type,
-			'tool_name'  => $tool_name,
-			'parameters' => is_array( $payload['parameters'] ?? null ) ? $payload['parameters'] : array(),
-			'tool_data'  => $payload,
+			'type'         => $type,
+			'tool_name'    => $tool_name,
+			'tool_call_id' => (string) ( $payload['tool_call_id'] ?? $metadata['tool_call_id'] ?? '' ),
+			'parameters'   => is_array( $payload['parameters'] ?? null ) ? $payload['parameters'] : array(),
+			'tool_data'    => $payload,
 		)
 	);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat#b816add"
+				"@extrachill/chat": "github:Extra-Chill/chat#fba7b09"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2657,7 +2657,7 @@
 		},
 		"node_modules/@extrachill/chat": {
 			"version": "0.12.4",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#b816add48d8b58eed46a895825f0df1385e13321",
+			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#fba7b0998220d7b42bf31ae028516fda120582b7",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat#b816add"
+		"@extrachill/chat": "github:Extra-Chill/chat#fba7b09"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",


### PR DESCRIPTION
## Summary
- Preserve canonical `tool_call_id` in frontend chat tool message metadata.
- Pin `@extrachill/chat` to call-ID based tool/result pairing.
- Prevent repeated tool calls from rendering cards above the assistant reply.

## Testing
- `npm run typecheck`
- `npm run build`
- `php -l inc/rest.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed repeated-tool ordering behavior, updated metadata preservation, and rebuilt the frontend package for Chris to review/test.
