### PR TITLE
fix: render Studio Web generation tool status

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -289,6 +289,21 @@ function renderQuestionCard( group: ToolGroup, context: ToolRendererContext ): R
 	} );
 }
 
+function renderGenerationCard( group: ToolGroup ): ReactNode {
+	return createElement(
+		'div',
+		{ className: `frontend-agent-chat__tool-card frontend-agent-chat__tool-card--generation${ group.success === false ? ' has-error' : '' }` },
+		createElement( 'div', { className: 'frontend-agent-chat__tool-card-title' }, __( 'WordPress preview', 'frontend-agent-chat' ) ),
+		createElement(
+			'p',
+			{ className: 'frontend-agent-chat__tool-card-copy' },
+			group.success === false
+				? __( 'The preview could not be started. Try again with a shorter brief or adjust the request.', 'frontend-agent-chat' )
+				: __( 'Studio Web is preparing your WordPress preview from the captured site brief.', 'frontend-agent-chat' )
+		)
+	);
+}
+
 function renderExpandIcon( path: string, viewBox: string ): ReactNode {
 	return createElement(
 		'svg',
@@ -477,6 +492,7 @@ export default function AgentChat( {
 			replace_post_blocks: renderDiffCard,
 			insert_content: renderDiffCard,
 			studio_web_propose_questions: renderQuestionCard,
+			studio_web_start_generation: renderGenerationCard,
 		} ),
 		[]
 	);

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -318,6 +318,34 @@
 	text-decoration: underline;
 }
 
+.frontend-agent-chat__tool-card {
+	margin: 8px 12px;
+	padding: 12px 14px;
+	border: 1px solid var(--frontend-agent-chat-border-color, #e2e8f0);
+	border-radius: 14px;
+	background: var(--frontend-agent-chat-message-bg, #fff);
+	color: var(--frontend-agent-chat-text-primary, #1e293b);
+	font-family: var(--frontend-agent-chat-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+	box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.frontend-agent-chat__tool-card.has-error {
+	border-color: var(--frontend-agent-chat-error-border, #fecaca);
+	background: var(--frontend-agent-chat-error-bg, #fef2f2);
+}
+
+.frontend-agent-chat__tool-card-title {
+	margin-bottom: 4px;
+	font-weight: 700;
+}
+
+.frontend-agent-chat__tool-card-copy {
+	margin: 0;
+	color: var(--frontend-agent-chat-text-muted, #64748b);
+	font-size: 13px;
+	line-height: 1.45;
+}
+
 .frontend-agent-chat__empty {
 	text-align: center;
 	padding: var(--frontend-agent-chat-spacing-lg, 24px);


### PR DESCRIPTION
## Summary
- Add a friendly renderer for the `studio_web_start_generation` tool.
- Show “WordPress preview” status instead of raw tool JSON for Studio Web generation.
- Keep backend implementation details out of the user-facing chat transcript.

## Testing
- `npm run typecheck`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added Studio Web-specific generation tool UI rendering for Chris to review/test.
