### PR TITLE
fix: restore chat bubble radius

### DIFF
--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -275,7 +275,7 @@
 	--ec-chat-session-hover-bg: var(--frontend-agent-chat-border-color, #e2e8f0);
 	--ec-chat-font-family: var(--frontend-agent-chat-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
 	--ec-chat-font-size: var(--frontend-agent-chat-font-size, 15px);
-	--ec-chat-border-radius: 0;
+	--ec-chat-border-radius: 14px;
 
 	background: var(--ec-chat-bg);
 	height: 100%;


### PR DESCRIPTION
## Summary
- Restore the embedded chat border radius from `0` to `14px`.
- Keeps message bubbles and composer controls from looking square while preserving the drawer/container layout.

## Testing
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Made the small CSS cleanup requested by Chris and verified the build.
