### PR TITLE
Add chat run-control REST adapter

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -313,6 +313,7 @@ function frontend_agent_chat_add_browser_principal_input( array $input ): array 
 		'key'   => $principal['id'],
 		'label' => 'Browser chat session',
 	);
+	$input['session_owner']     = $input['transcript_owner'];
 	return $input;
 }
 
@@ -387,12 +388,17 @@ function frontend_agent_chat_allow_browser_conversation_sessions( bool $allowed,
 	}
 
 	$input_principal  = is_array( $input['principal'] ?? null ) ? $input['principal'] : array();
-	$transcript_owner = is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : array();
+	$session_owner    = is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : array();
+	$transcript_owner = is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : $session_owner;
 	if (
 		'browser' !== (string) ( $input_principal['owner_type'] ?? '' ) ||
 		(string) ( $input_principal['owner_key'] ?? '' ) !== $principal['id'] ||
 		'browser' !== (string) ( $transcript_owner['type'] ?? '' ) ||
-		(string) ( $transcript_owner['key'] ?? '' ) !== $principal['id']
+		(string) ( $transcript_owner['key'] ?? '' ) !== $principal['id'] ||
+		( ! empty( $session_owner ) && (
+			'browser' !== (string) ( $session_owner['type'] ?? '' ) ||
+			(string) ( $session_owner['key'] ?? '' ) !== $principal['id']
+		) )
 	) {
 		return false;
 	}
@@ -405,9 +411,85 @@ function frontend_agent_chat_allow_browser_conversation_sessions( bool $allowed,
 	return frontend_agent_chat_user_can_see( frontend_agent_chat_resolve_agent( $agent_slug ) );
 }
 
+/**
+ * Allow anonymous browser principals to use their own chat run-control records.
+ *
+ * @param bool  $allowed Existing permission decision.
+ * @param array $input   Ability input.
+ * @return bool Whether the ability may run.
+ */
+function frontend_agent_chat_allow_browser_run_control( bool $allowed, array $input ): bool {
+	if ( $allowed || is_user_logged_in() ) {
+		return $allowed;
+	}
+
+	$principal = frontend_agent_chat_get_browser_principal();
+	if ( ! $principal ) {
+		return false;
+	}
+
+	$input_principal = is_array( $input['principal'] ?? null ) ? $input['principal'] : array();
+	$session_owner   = is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : array();
+
+	return 'browser' === (string) ( $input_principal['owner_type'] ?? '' )
+		&& (string) ( $input_principal['owner_key'] ?? '' ) === $principal['id']
+		&& 'browser' === (string) ( $session_owner['type'] ?? '' )
+		&& (string) ( $session_owner['key'] ?? '' ) === $principal['id'];
+}
+
+/**
+ * Check whether an ability is registered.
+ *
+ * @param string $name Ability name.
+ * @return bool Whether the ability is available.
+ */
+function frontend_agent_chat_has_ability( string $name ): bool {
+	if ( function_exists( 'wp_has_ability' ) ) {
+		return (bool) wp_has_ability( $name );
+	}
+
+	return function_exists( 'wp_get_ability' ) && null !== wp_get_ability( $name );
+}
+
+/**
+ * Detect run-control support for the current frontend chat principal.
+ *
+ * @param string $agent_slug Optional selected agent slug.
+ * @return array{chat_run_status:bool,chat_run_cancel:bool,chat_message_queue:bool}
+ */
+function frontend_agent_chat_get_run_control_capabilities( string $agent_slug = '' ): array {
+	$agent_slug = sanitize_title( $agent_slug );
+	$can_chat   = true;
+
+	if ( '' !== $agent_slug ) {
+		$can_chat = frontend_agent_chat_user_can_see( frontend_agent_chat_resolve_agent( $agent_slug ) );
+	}
+
+	$capabilities = array(
+		'chat_run_status'   => $can_chat && frontend_agent_chat_has_ability( 'agents/get-chat-run' ),
+		'chat_run_cancel'   => $can_chat && frontend_agent_chat_has_ability( 'agents/cancel-chat-run' ),
+		'chat_message_queue' => $can_chat && frontend_agent_chat_has_ability( 'agents/queue-chat-message' ),
+	);
+
+	/**
+	 * Filter detected frontend chat run-control capabilities.
+	 *
+	 * @param array  $capabilities Capability flags.
+	 * @param string $agent_slug    Selected agent slug, when known.
+	 */
+	$filtered = apply_filters( 'frontend_agent_chat_run_control_capabilities', $capabilities, $agent_slug );
+
+	return is_array( $filtered ) ? array(
+		'chat_run_status'   => ! empty( $filtered['chat_run_status'] ),
+		'chat_run_cancel'   => ! empty( $filtered['chat_run_cancel'] ),
+		'chat_message_queue' => ! empty( $filtered['chat_message_queue'] ),
+	) : $capabilities;
+}
+
 if ( function_exists( 'add_filter' ) ) {
 	add_filter( 'agents_api_execution_principal', 'frontend_agent_chat_resolve_browser_execution_principal', 10, 2 );
 	add_filter( 'agents_conversation_sessions_permission', 'frontend_agent_chat_allow_browser_conversation_sessions', 10, 2 );
+	add_filter( 'agents_chat_run_control_permission', 'frontend_agent_chat_allow_browser_run_control', 10, 2 );
 }
 
 /**

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -155,6 +155,7 @@ function frontend_agent_chat_enqueue() {
 		'expandIconViewBox' => frontend_agent_chat_sanitize_svg_view_box( $config['expand_icon_view_box'] ?? '0 0 24 24' ),
 		'layout'            => 'inline' === ( $config['layout'] ?? '' ) ? 'inline' : 'floating',
 		'isLoggedIn'        => is_user_logged_in(),
+		'capabilities'      => frontend_agent_chat_get_run_control_capabilities( (string) ( $agent['agent_slug'] ?? $default_agent_slug ) ),
 	);
 
 	/**

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -64,6 +64,36 @@ function frontend_agent_chat_register_rest_routes(): void {
 
 	register_rest_route(
 		'frontend-agent-chat/v1',
+		'/chat/queue',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'frontend_agent_chat_rest_queue_message',
+			'permission_callback' => 'frontend_agent_chat_rest_can_chat',
+		)
+	);
+
+	register_rest_route(
+		'frontend-agent-chat/v1',
+		'/chat/runs/(?P<run_id>[^/]+)',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'frontend_agent_chat_rest_get_run',
+			'permission_callback' => 'frontend_agent_chat_rest_can_chat',
+		)
+	);
+
+	register_rest_route(
+		'frontend-agent-chat/v1',
+		'/chat/runs/(?P<run_id>[^/]+)/cancel',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'frontend_agent_chat_rest_cancel_run',
+			'permission_callback' => 'frontend_agent_chat_rest_can_chat',
+		)
+	);
+
+	register_rest_route(
+		'frontend-agent-chat/v1',
 		'/chat/continue',
 		array(
 			'methods'             => WP_REST_Server::CREATABLE,
@@ -140,6 +170,7 @@ function frontend_agent_chat_rest_bootstrap(): WP_REST_Response {
 				'browser_principal_id'      => is_array( $principal ) ? $principal['id'] : '',
 				'browser_principal_secret'  => false,
 				'session_persistence_scope' => is_user_logged_in() ? 'user' : 'browser',
+				'capabilities'              => frontend_agent_chat_get_run_control_capabilities(),
 			),
 		)
 	);
@@ -355,6 +386,7 @@ function frontend_agent_chat_rest_send_message( WP_REST_Request $request ) {
 			'success' => true,
 			'data'    => array(
 				'session_id'        => $result_session_id,
+				'run_id'            => sanitize_text_field( (string) ( $result['run_id'] ?? '' ) ),
 				'response'          => (string) ( $result['reply'] ?? '' ),
 				'tool_calls'        => is_array( $result['tool_calls'] ?? null ) ? $result['tool_calls'] : array(),
 				'conversation'      => $conversation,
@@ -364,6 +396,140 @@ function frontend_agent_chat_rest_send_message( WP_REST_Request $request ) {
 				'turn_number'       => 1,
 				'max_turns_reached' => false,
 			),
+		)
+	);
+}
+
+/**
+ * Get the status for a canonical Agents API chat run.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function frontend_agent_chat_rest_get_run( WP_REST_Request $request ) {
+	$run_id     = sanitize_text_field( (string) $request['run_id'] );
+	$session_id = sanitize_text_field( (string) $request->get_param( 'session_id' ) );
+	if ( '' === $run_id || '' === $session_id ) {
+		return new WP_Error( 'frontend_agent_chat_invalid_run', __( 'run_id and session_id are required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+	}
+
+	$result = frontend_agent_chat_execute_ability(
+		'agents/get-chat-run',
+		frontend_agent_chat_add_browser_principal_input(
+			array(
+				'run_id'     => $run_id,
+				'session_id' => $session_id,
+			)
+		)
+	);
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response(
+		array(
+			'success' => true,
+			'data'    => frontend_agent_chat_normalize_run_control_result( is_array( $result ) ? $result : array(), $run_id, $session_id ),
+		)
+	);
+}
+
+/**
+ * Cancel a canonical Agents API chat run.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function frontend_agent_chat_rest_cancel_run( WP_REST_Request $request ) {
+	$run_id     = sanitize_text_field( (string) $request['run_id'] );
+	$session_id = sanitize_text_field( (string) $request->get_param( 'session_id' ) );
+	if ( '' === $run_id || '' === $session_id ) {
+		return new WP_Error( 'frontend_agent_chat_invalid_run', __( 'run_id and session_id are required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+	}
+
+	$result = frontend_agent_chat_execute_ability(
+		'agents/cancel-chat-run',
+		frontend_agent_chat_add_browser_principal_input(
+			array(
+				'run_id'     => $run_id,
+				'session_id' => $session_id,
+			)
+		)
+	);
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	$data = frontend_agent_chat_normalize_run_control_result( is_array( $result ) ? $result : array(), $run_id, $session_id );
+	$data['cancelled'] = (bool) ( is_array( $result ) && ( $result['cancelled'] ?? false ) );
+
+	return rest_ensure_response(
+		array(
+			'success' => true,
+			'data'    => $data,
+		)
+	);
+}
+
+/**
+ * Queue a follow-up chat message through the canonical Agents API queue ability.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function frontend_agent_chat_rest_queue_message( WP_REST_Request $request ) {
+	$message = trim( (string) $request->get_param( 'message' ) );
+	if ( '' === $message ) {
+		return new WP_Error( 'frontend_agent_chat_empty_message', __( 'Message cannot be empty.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+	}
+
+	$config     = frontend_agent_chat_get_config();
+	$agent_slug = frontend_agent_chat_rest_get_agent_slug( $request, frontend_agent_chat_get_default_agent_slug( $config ) );
+	$session_id = sanitize_text_field( (string) $request->get_param( 'session_id' ) );
+	if ( '' === $agent_slug || '' === $session_id ) {
+		return new WP_Error( 'frontend_agent_chat_invalid_queue_message', __( 'agent and session_id are required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+	}
+
+	$attachments = $request->get_param( 'attachments' );
+	$queue_input = array(
+		'agent'          => $agent_slug,
+		'session_id'     => $session_id,
+		'message'        => $message,
+		'attachments'    => is_array( $attachments ) ? $attachments : array(),
+		'client_context' => array(
+			'source'       => 'rest',
+			'client_name'  => 'frontend-agent-chat',
+			'connector_id' => 'frontend-agent-chat',
+		),
+	);
+
+	/**
+	 * Filter the canonical agents/queue-chat-message input sent by the frontend chat widget.
+	 *
+	 * @param array           $queue_input Canonical queue input.
+	 * @param WP_REST_Request $request     REST request.
+	 * @param string          $agent_slug  Selected agent slug.
+	 * @param array           $config      Frontend chat configuration.
+	 */
+	/** @var mixed $queue_input */
+	$queue_input = apply_filters( 'frontend_agent_chat_queue_input', $queue_input, $request, $agent_slug, $config );
+
+	$result = frontend_agent_chat_execute_ability( 'agents/queue-chat-message', frontend_agent_chat_add_browser_principal_input( is_array( $queue_input ) ? $queue_input : array() ) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	$result = is_array( $result ) ? $result : array();
+	return rest_ensure_response(
+		array(
+			'success' => true,
+			'data'    => array(
+				'queued_message_id' => sanitize_text_field( (string) ( $result['queued_message_id'] ?? '' ) ),
+				'session_id'        => sanitize_text_field( (string) ( $result['session_id'] ?? $session_id ) ),
+				'run_id'            => sanitize_text_field( (string) ( $result['run_id'] ?? '' ) ),
+				'position'          => (int) ( $result['position'] ?? 0 ),
+				'status'            => sanitize_key( (string) ( $result['status'] ?? 'queued' ) ),
+			)
 		)
 	);
 }
@@ -548,6 +714,25 @@ function frontend_agent_chat_rest_mark_session_read( WP_REST_Request $request ):
 				'session_id' => sanitize_text_field( (string) $request['session_id'] ),
 			),
 		)
+	);
+}
+
+/**
+ * Normalize canonical chat run-control ability output for REST clients.
+ *
+ * @param array  $result     Ability result.
+ * @param string $run_id     Fallback run id.
+ * @param string $session_id Fallback session id.
+ * @return array
+ */
+function frontend_agent_chat_normalize_run_control_result( array $result, string $run_id, string $session_id ): array {
+	return array(
+		'run_id'     => sanitize_text_field( (string) ( $result['run_id'] ?? $run_id ) ),
+		'session_id' => sanitize_text_field( (string) ( $result['session_id'] ?? $session_id ) ),
+		'status'     => sanitize_key( (string) ( $result['status'] ?? '' ) ),
+		'started_at' => sanitize_text_field( (string) ( $result['started_at'] ?? '' ) ),
+		'updated_at' => sanitize_text_field( (string) ( $result['updated_at'] ?? '' ) ),
+		'metadata'   => is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array(),
 	);
 }
 

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -494,6 +494,7 @@ function frontend_agent_chat_rest_queue_message( WP_REST_Request $request ) {
 	$queue_input = array(
 		'agent'          => $agent_slug,
 		'session_id'     => $session_id,
+		'run_id'         => sanitize_text_field( (string) $request->get_param( 'run_id' ) ),
 		'message'        => $message,
 		'attachments'    => is_array( $attachments ) ? $attachments : array(),
 		'client_context' => array(

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat#fba7b09"
+				"@extrachill/chat": "github:Extra-Chill/chat#318014d44092174d7639f5d906c3bb6381ed6571"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2657,7 +2657,8 @@
 		},
 		"node_modules/@extrachill/chat": {
 			"version": "0.12.4",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#fba7b0998220d7b42bf31ae028516fda120582b7",
+			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#318014d44092174d7639f5d906c3bb6381ed6571",
+			"integrity": "sha512-TB0hPhv8EA604YnuIRFwCakX2ZBTzQkqbNnhZ8SWlL20Gjcj3Qk1ycCKmr4uNDCBs37RtDOlIrh+ou68snznVQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat#fba7b09"
+		"@extrachill/chat": "github:Extra-Chill/chat#318014d44092174d7639f5d906c3bb6381ed6571"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -24,7 +24,7 @@ import {
 	useClientContextMetadata,
 	parseCanonicalDiffFromToolGroup,
 } from '@extrachill/chat';
-import type { ChatMessageSuggestion, ToolGroup, DiffData, FetchFn, MediaUploadFn, ToolRendererContext, QuestionChoice } from '@extrachill/chat';
+import type { ChatMessageSuggestion, ToolGroup, DiffData, FetchFn, MediaUploadFn, ToolRendererContext, QuestionChoice, ChatRunCapabilities, CancelRunInput, QueueMessageInput, QueueMessageResult } from '@extrachill/chat';
 import type { ChangeEvent, ReactNode } from 'react';
 
 /**
@@ -61,6 +61,11 @@ interface AgentChatProps {
 		actionUrl?: string;
 	};
 	messageSuggestions?: ChatMessageSuggestion[];
+	capabilities?: {
+		chat_run_status?: boolean;
+		chat_run_cancel?: boolean;
+		chat_message_queue?: boolean;
+	};
 }
 
 interface BootstrapResponse {
@@ -70,6 +75,21 @@ interface BootstrapResponse {
 		browser_principal_ready?: boolean;
 		had_browser_principal?: boolean;
 		session_persistence_scope?: 'user' | 'browser';
+		capabilities?: AgentChatProps['capabilities'];
+	};
+}
+
+interface RunControlResponse {
+	success?: boolean;
+	data?: {
+		run_id?: string;
+		session_id?: string;
+		status?: string;
+		started_at?: string;
+		updated_at?: string;
+		metadata?: Record< string, unknown >;
+		queued_message_id?: string;
+		position?: number;
 	};
 }
 
@@ -152,6 +172,71 @@ function createAgentFetch( agentSlug: string ): FetchFn {
 				: options.data,
 			headers: options.headers,
 		} );
+	};
+}
+
+function createRunCapabilities( capabilities?: AgentChatProps['capabilities'] ): ChatRunCapabilities {
+	return {
+		cancel: !! capabilities?.chat_run_cancel,
+		queue: !! capabilities?.chat_message_queue,
+	};
+}
+
+function getRunId( metadata: Record< string, unknown > ): string | null {
+	const runId = metadata.run_id ?? metadata.runId;
+	return typeof runId === 'string' && runId.trim() ? runId : null;
+}
+
+function createCancelRun( fetchFn: FetchFn, basePath: string ): ( input: CancelRunInput ) => Promise< void > {
+	return async ( input ) => {
+		await fetchFn( {
+			path: `${ basePath }/runs/${ encodeURIComponent( input.runId ) }/cancel`,
+			method: 'POST',
+			data: { session_id: input.sessionId },
+		} );
+	};
+}
+
+function normalizeQueueResult( response: RunControlResponse ): QueueMessageResult {
+	const data = response.data ?? {};
+	return {
+		queuedMessageId: data.queued_message_id,
+		runId: data.run_id,
+		sessionId: data.session_id,
+		status: data.status as QueueMessageResult['status'],
+		startedAt: data.started_at,
+		updatedAt: data.updated_at,
+		metadata: data.metadata,
+		position: data.position,
+	};
+}
+
+function createQueueMessage( fetchFn: FetchFn, uploadFn: MediaUploadFn, basePath: string ): ( input: QueueMessageInput ) => Promise< QueueMessageResult > {
+	return async ( input ) => {
+		const attachments = input.files?.length
+			? await Promise.all( input.files.map( async ( file ) => {
+				const uploaded = await uploadFn( file );
+				return {
+					filename: file.name,
+					mime_type: file.type,
+					url: uploaded.url,
+					media_id: uploaded.media_id,
+				};
+			} ) )
+			: [];
+
+		const response = await fetchFn( {
+			path: `${ basePath }/queue`,
+			method: 'POST',
+			data: {
+				session_id: input.sessionId,
+				run_id: input.runId,
+				message: input.content,
+				attachments,
+			},
+		} ) as RunControlResponse;
+
+		return normalizeQueueResult( response );
 	};
 }
 
@@ -366,6 +451,7 @@ export default function AgentChat( {
 	loadingMessages = true,
 	persistenceCta,
 	messageSuggestions,
+	capabilities,
 }: AgentChatProps ) {
 	const isInline = layout === 'inline';
 	const [ isOpen, setIsOpen ] = useState( isInline );
@@ -388,6 +474,9 @@ export default function AgentChat( {
 	const activeAgentName = selectedAgent?.name ?? agentName;
 	const activeAgentDescription = selectedAgent?.description ?? agentDescription;
 	const agentFetch = useMemo( () => createAgentFetch( activeAgentSlug ), [ activeAgentSlug ] );
+	const runCapabilities = useMemo( () => createRunCapabilities( capabilities ), [ capabilities ] );
+	const cancelRun = useMemo( () => createCancelRun( agentFetch, basePath ), [ agentFetch, basePath ] );
+	const queueMessage = useMemo( () => createQueueMessage( agentFetch, wpMediaUpload, basePath ), [ agentFetch, basePath ] );
 	const open = useCallback( () => setIsOpen( true ), [] );
 	const close = useCallback( () => {
 		if ( isInline ) {
@@ -633,6 +722,11 @@ export default function AgentChat( {
 					messageSuggestionsLabel: __( 'Try asking', 'frontend-agent-chat' ),
 					loadingMessages,
 					mediaUploadFn: wpMediaUpload,
+					runCapabilities,
+					getRunId,
+					onCancelRun: cancelRun,
+					onQueueMessage: queueMessage,
+					cancelLabel: __( 'Stop', 'frontend-agent-chat' ),
 					processingLabel: ( turnCount: number ) =>
 						sprintf(
 							/* translators: %d: processing turn count. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,11 @@ declare global {
 				actionUrl?: string;
 			};
 			messageSuggestions?: ChatMessageSuggestion[];
+			capabilities?: {
+				chat_run_status?: boolean;
+				chat_run_cancel?: boolean;
+				chat_message_queue?: boolean;
+			};
 		};
 	}
 }
@@ -104,6 +109,7 @@ function init(): void {
 			loadingMessages: config.loadingMessages ?? true,
 			persistenceCta: config.persistenceCta,
 			messageSuggestions: config.messageSuggestions,
+			capabilities: config.capabilities,
 		} )
 	);
 }

--- a/tests/run-control-smoke.php
+++ b/tests/run-control-smoke.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Pure-PHP smoke test for Agents API chat run-control adapter support.
+ *
+ * Run with: php tests/run-control-smoke.php
+ *
+ * @package FrontendAgentChat
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+if ( ! defined( 'FRONTEND_AGENT_CHAT_BROWSER_COOKIE' ) ) {
+	define( 'FRONTEND_AGENT_CHAT_BROWSER_COOKIE', 'frontend_agent_chat_browser' );
+}
+
+class WP_Error {
+	public function __construct( public string $code, public string $message = '', public array $data = array() ) {}
+}
+
+class WP_REST_Server {
+	public const READABLE  = 'GET';
+	public const CREATABLE = 'POST';
+	public const DELETABLE = 'DELETE';
+}
+
+class WP_REST_Response {}
+
+class WP_REST_Request implements ArrayAccess {
+	public function __construct( private array $params = array() ) {}
+
+	public function get_param( string $name ) {
+		return $this->params[ $name ] ?? null;
+	}
+
+	public function get_route(): string {
+		return (string) ( $this->params['_route'] ?? '' );
+	}
+
+	public function offsetExists( mixed $offset ): bool {
+		return isset( $this->params[ $offset ] );
+	}
+
+	public function offsetGet( mixed $offset ): mixed {
+		return $this->params[ $offset ] ?? null;
+	}
+
+	public function offsetSet( mixed $offset, mixed $value ): void {
+		$this->params[ $offset ] = $value;
+	}
+
+	public function offsetUnset( mixed $offset ): void {
+		unset( $this->params[ $offset ] );
+	}
+}
+
+class FrontendAgentChatRunControlFakeAbility {
+	public function __construct( private string $name ) {}
+
+	public function execute( array $input ) {
+		$GLOBALS['frontend_agent_chat_run_control_calls'][] = array( $this->name, $input );
+
+		if ( 'agents/list-accessible-agents' === $this->name ) {
+			return array( 'agents' => $GLOBALS['frontend_agent_chat_run_control_agents'] );
+		}
+
+		if ( 'agents/can-access-agent' === $this->name ) {
+			return array( 'allowed' => true );
+		}
+
+		if ( 'agents/get-chat-run' === $this->name ) {
+			return array(
+				'run_id'     => $input['run_id'],
+				'session_id' => $input['session_id'],
+				'status'     => 'running',
+				'updated_at' => '2026-05-29T00:00:00Z',
+				'metadata'   => array( 'source' => 'smoke' ),
+			);
+		}
+
+		if ( 'agents/cancel-chat-run' === $this->name ) {
+			return array(
+				'run_id'     => $input['run_id'],
+				'session_id' => $input['session_id'],
+				'cancelled'  => true,
+				'status'     => 'cancelling',
+			);
+		}
+
+		if ( 'agents/queue-chat-message' === $this->name ) {
+			return array(
+				'queued_message_id' => 'queued-1',
+				'session_id'        => $input['session_id'],
+				'run_id'            => 'run-next',
+				'position'          => 1,
+				'status'            => 'queued',
+			);
+		}
+
+		return array();
+	}
+}
+
+function __( $text, $domain = null ) {
+	unset( $domain );
+	return $text;
+}
+
+function sanitize_title( $value ) {
+	$value = strtolower( (string) $value );
+	$value = preg_replace( '/[^a-z0-9_-]+/', '-', $value );
+	return trim( (string) $value, '-' );
+}
+
+function sanitize_text_field( $value ) {
+	return trim( (string) $value );
+}
+
+function sanitize_key( $value ) {
+	return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) );
+}
+
+function apply_filters( $hook, $value ) {
+	unset( $hook );
+	return $value;
+}
+
+function add_action() {}
+function register_rest_route() {}
+function add_filter() {}
+
+function get_option( $name, $default = false ) {
+	unset( $name );
+	return $default;
+}
+
+function is_multisite() {
+	return false;
+}
+
+function wp_parse_args( $args, $defaults = array() ) {
+	return array_merge( $defaults, is_array( $args ) ? $args : array() );
+}
+
+function wp_has_ability( string $name ) {
+	return in_array( $name, $GLOBALS['frontend_agent_chat_run_control_abilities'], true );
+}
+
+function wp_get_ability( string $name ) {
+	return wp_has_ability( $name ) ? new FrontendAgentChatRunControlFakeAbility( $name ) : null;
+}
+
+function is_wp_error( $value ) {
+	return $value instanceof WP_Error;
+}
+
+function is_user_logged_in() {
+	return false;
+}
+
+function wp_unslash( $value ) {
+	return $value;
+}
+
+function wp_salt( $scheme = 'auth' ) {
+	unset( $scheme );
+	return 'frontend-agent-chat-run-control-smoke-salt';
+}
+
+function rest_ensure_response( $response ) {
+	return $response;
+}
+
+require_once dirname( __DIR__ ) . '/inc/config.php';
+require_once dirname( __DIR__ ) . '/inc/rest.php';
+
+$failures = array();
+$passes   = 0;
+
+function frontend_agent_chat_run_control_assert_equals( $expected, $actual, string $message, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		return;
+	}
+
+	$failures[] = $message . ' expected ' . var_export( $expected, true ) . ' got ' . var_export( $actual, true );
+}
+
+echo "frontend-agent-chat-run-control-smoke\n";
+
+$GLOBALS['frontend_agent_chat_run_control_calls']     = array();
+$GLOBALS['frontend_agent_chat_run_control_agents']    = array(
+	array(
+		'slug'        => 'demo-agent',
+		'label'       => 'Demo Agent',
+		'description' => 'Answers user questions.',
+	),
+);
+$GLOBALS['frontend_agent_chat_run_control_abilities'] = array(
+	'agents/list-accessible-agents',
+	'agents/can-access-agent',
+	'agents/get-chat-run',
+	'agents/cancel-chat-run',
+	'agents/queue-chat-message',
+);
+
+$_COOKIE[ FRONTEND_AGENT_CHAT_BROWSER_COOKIE ] = str_repeat( 'b', 64 );
+
+$capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_status'], 'status capability follows ability availability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_cancel'], 'cancel capability follows ability availability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_message_queue'], 'queue capability follows ability availability', $failures, $passes );
+
+$run_response = frontend_agent_chat_rest_get_run( new WP_REST_Request( array( 'run_id' => 'run-1', 'session_id' => 'session-1', 'agent' => 'demo-agent' ) ) );
+frontend_agent_chat_run_control_assert_equals( 'running', $run_response['data']['status'] ?? '', 'run status is normalized', $failures, $passes );
+
+$cancel_response = frontend_agent_chat_rest_cancel_run( new WP_REST_Request( array( 'run_id' => 'run-1', 'session_id' => 'session-1', 'agent' => 'demo-agent' ) ) );
+frontend_agent_chat_run_control_assert_equals( true, $cancel_response['data']['cancelled'] ?? false, 'cancel response is normalized', $failures, $passes );
+
+$queue_response = frontend_agent_chat_rest_queue_message( new WP_REST_Request( array( 'message' => 'next', 'session_id' => 'session-1', 'agent' => 'demo-agent' ) ) );
+frontend_agent_chat_run_control_assert_equals( 'queued-1', $queue_response['data']['queued_message_id'] ?? '', 'queue response is normalized', $failures, $passes );
+
+$last_call = end( $GLOBALS['frontend_agent_chat_run_control_calls'] );
+frontend_agent_chat_run_control_assert_equals( 'agents/queue-chat-message', $last_call[0] ?? '', 'queue route calls canonical ability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( 'browser', $last_call[1]['transcript_owner']['type'] ?? '', 'queue preserves browser owner', $failures, $passes );
+
+$GLOBALS['frontend_agent_chat_run_control_abilities'] = array( 'agents/list-accessible-agents', 'agents/can-access-agent' );
+$capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' );
+frontend_agent_chat_run_control_assert_equals( false, $capabilities['chat_run_status'], 'missing upstream ability disables status capability', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo "Frontend run-control smoke passed ({$passes} assertions).\n";

--- a/tests/run-control-smoke.php
+++ b/tests/run-control-smoke.php
@@ -217,12 +217,13 @@ frontend_agent_chat_run_control_assert_equals( 'running', $run_response['data'][
 $cancel_response = frontend_agent_chat_rest_cancel_run( new WP_REST_Request( array( 'run_id' => 'run-1', 'session_id' => 'session-1', 'agent' => 'demo-agent' ) ) );
 frontend_agent_chat_run_control_assert_equals( true, $cancel_response['data']['cancelled'] ?? false, 'cancel response is normalized', $failures, $passes );
 
-$queue_response = frontend_agent_chat_rest_queue_message( new WP_REST_Request( array( 'message' => 'next', 'session_id' => 'session-1', 'agent' => 'demo-agent' ) ) );
+$queue_response = frontend_agent_chat_rest_queue_message( new WP_REST_Request( array( 'message' => 'next', 'session_id' => 'session-1', 'run_id' => 'run-1', 'agent' => 'demo-agent' ) ) );
 frontend_agent_chat_run_control_assert_equals( 'queued-1', $queue_response['data']['queued_message_id'] ?? '', 'queue response is normalized', $failures, $passes );
 
 $last_call = end( $GLOBALS['frontend_agent_chat_run_control_calls'] );
 frontend_agent_chat_run_control_assert_equals( 'agents/queue-chat-message', $last_call[0] ?? '', 'queue route calls canonical ability', $failures, $passes );
 frontend_agent_chat_run_control_assert_equals( 'browser', $last_call[1]['transcript_owner']['type'] ?? '', 'queue preserves browser owner', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( 'run-1', $last_call[1]['run_id'] ?? '', 'queue forwards active run id', $failures, $passes );
 
 $GLOBALS['frontend_agent_chat_run_control_abilities'] = array( 'agents/list-accessible-agents', 'agents/can-access-agent' );
 $capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' );


### PR DESCRIPTION
## Summary
- Adds frontend REST adapter routes for canonical Agents API chat run status, cancellation, and queued messages.
- Passes `run_id` through from `agents/chat` responses and exposes run-control capability flags in bootstrap/localized config based on ability availability.
- Wires the merged `@extrachill/chat` run-control props (`runCapabilities`, `onCancelRun`, `onQueueMessage`) to the generic frontend-agent-chat REST adapter.
- Preserves browser-principal/session-owner handling for anonymous run-control calls.

## Upstream dependencies
- Uses the merged Agents API run-control contract from Automattic/agents-api#237 (`e52f19340c349d29d551bd65b6a30bf483800361`).
- Updates `@extrachill/chat` to Extra-Chill/chat#39 merge commit (`318014d44092174d7639f5d906c3bb6381ed6571`) for generic run-control UI props.

Fixes #47.

## Verification
- `php tests/principal-access-smoke.php`
- `php tests/tool-transcript-message-filter-smoke.php`
- `php tests/run-control-smoke.php`
- `php -l inc/config.php`
- `php -l inc/rest.php`
- `php -l inc/enqueue.php`
- `php -l tests/run-control-smoke.php`
- `npm run typecheck`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the frontend-agent-chat REST adapter, capability detection, browser-principal preservation, smoke coverage, and generic @extrachill/chat run-control wiring against the merged contracts. Chris remains responsible for review and validation.