### PR TITLE
Detect default chat run-control abilities

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -452,29 +452,6 @@ function frontend_agent_chat_has_ability( string $name ): bool {
 }
 
 /**
- * Check whether the selected chat runtime exposes a run-control handler.
- *
- * Agents API registers canonical run-control abilities globally, but each
- * runtime owns whether a specific agent can actually report status, cancel, or
- * queue. Capability detection must account for both layers so clients do not
- * expose controls that a selected agent cannot honor.
- *
- * @param string $handler_filter Runtime handler filter name.
- * @param string $agent_slug     Selected agent slug.
- * @return bool Whether a callable runtime handler is available.
- */
-function frontend_agent_chat_has_run_control_handler( string $handler_filter, string $agent_slug ): bool {
-	if ( '' === $agent_slug ) {
-		return false;
-	}
-
-	$input = array( 'agent' => $agent_slug );
-	$input = frontend_agent_chat_add_browser_principal_input( $input );
-
-	return is_callable( apply_filters( $handler_filter, null, $input ) );
-}
-
-/**
  * Detect run-control support for the current frontend chat principal.
  *
  * @param string $agent_slug Optional selected agent slug.
@@ -488,16 +465,15 @@ function frontend_agent_chat_get_run_control_capabilities( string $agent_slug = 
 		$can_chat = frontend_agent_chat_user_can_see( frontend_agent_chat_resolve_agent( $agent_slug ) );
 	}
 
+	$result = $can_chat ? frontend_agent_chat_execute_ability(
+		'agents/chat-run-control-capabilities',
+		frontend_agent_chat_add_browser_principal_input( array( 'agent' => $agent_slug ) )
+	) : null;
+
 	$capabilities = array(
-		'chat_run_status'   => $can_chat
-			&& frontend_agent_chat_has_ability( 'agents/get-chat-run' )
-			&& frontend_agent_chat_has_run_control_handler( 'wp_agent_chat_run_status_handler', $agent_slug ),
-		'chat_run_cancel'   => $can_chat
-			&& frontend_agent_chat_has_ability( 'agents/cancel-chat-run' )
-			&& frontend_agent_chat_has_run_control_handler( 'wp_agent_chat_run_cancel_handler', $agent_slug ),
-		'chat_message_queue' => $can_chat
-			&& frontend_agent_chat_has_ability( 'agents/queue-chat-message' )
-			&& frontend_agent_chat_has_run_control_handler( 'wp_agent_chat_message_queue_handler', $agent_slug ),
+		'chat_run_status'   => is_array( $result ) && ! empty( $result['chat_run_status'] ),
+		'chat_run_cancel'   => is_array( $result ) && ! empty( $result['chat_run_cancel'] ),
+		'chat_message_queue' => is_array( $result ) && ! empty( $result['chat_message_queue'] ),
 	);
 
 	/**

--- a/inc/config.php
+++ b/inc/config.php
@@ -465,15 +465,10 @@ function frontend_agent_chat_get_run_control_capabilities( string $agent_slug = 
 		$can_chat = frontend_agent_chat_user_can_see( frontend_agent_chat_resolve_agent( $agent_slug ) );
 	}
 
-	$result = $can_chat ? frontend_agent_chat_execute_ability(
-		'agents/chat-run-control-capabilities',
-		frontend_agent_chat_add_browser_principal_input( array( 'agent' => $agent_slug ) )
-	) : null;
-
 	$capabilities = array(
-		'chat_run_status'   => is_array( $result ) && ! empty( $result['chat_run_status'] ),
-		'chat_run_cancel'   => is_array( $result ) && ! empty( $result['chat_run_cancel'] ),
-		'chat_message_queue' => is_array( $result ) && ! empty( $result['chat_message_queue'] ),
+		'chat_run_status'   => $can_chat && frontend_agent_chat_has_ability( 'agents/get-chat-run' ),
+		'chat_run_cancel'   => $can_chat && frontend_agent_chat_has_ability( 'agents/cancel-chat-run' ),
+		'chat_message_queue' => $can_chat && frontend_agent_chat_has_ability( 'agents/queue-chat-message' ),
 	);
 
 	/**

--- a/inc/config.php
+++ b/inc/config.php
@@ -452,6 +452,29 @@ function frontend_agent_chat_has_ability( string $name ): bool {
 }
 
 /**
+ * Check whether the selected chat runtime exposes a run-control handler.
+ *
+ * Agents API registers canonical run-control abilities globally, but each
+ * runtime owns whether a specific agent can actually report status, cancel, or
+ * queue. Capability detection must account for both layers so clients do not
+ * expose controls that a selected agent cannot honor.
+ *
+ * @param string $handler_filter Runtime handler filter name.
+ * @param string $agent_slug     Selected agent slug.
+ * @return bool Whether a callable runtime handler is available.
+ */
+function frontend_agent_chat_has_run_control_handler( string $handler_filter, string $agent_slug ): bool {
+	if ( '' === $agent_slug ) {
+		return false;
+	}
+
+	$input = array( 'agent' => $agent_slug );
+	$input = frontend_agent_chat_add_browser_principal_input( $input );
+
+	return is_callable( apply_filters( $handler_filter, null, $input ) );
+}
+
+/**
  * Detect run-control support for the current frontend chat principal.
  *
  * @param string $agent_slug Optional selected agent slug.
@@ -466,9 +489,15 @@ function frontend_agent_chat_get_run_control_capabilities( string $agent_slug = 
 	}
 
 	$capabilities = array(
-		'chat_run_status'   => $can_chat && frontend_agent_chat_has_ability( 'agents/get-chat-run' ),
-		'chat_run_cancel'   => $can_chat && frontend_agent_chat_has_ability( 'agents/cancel-chat-run' ),
-		'chat_message_queue' => $can_chat && frontend_agent_chat_has_ability( 'agents/queue-chat-message' ),
+		'chat_run_status'   => $can_chat
+			&& frontend_agent_chat_has_ability( 'agents/get-chat-run' )
+			&& frontend_agent_chat_has_run_control_handler( 'wp_agent_chat_run_status_handler', $agent_slug ),
+		'chat_run_cancel'   => $can_chat
+			&& frontend_agent_chat_has_ability( 'agents/cancel-chat-run' )
+			&& frontend_agent_chat_has_run_control_handler( 'wp_agent_chat_run_cancel_handler', $agent_slug ),
+		'chat_message_queue' => $can_chat
+			&& frontend_agent_chat_has_ability( 'agents/queue-chat-message' )
+			&& frontend_agent_chat_has_run_control_handler( 'wp_agent_chat_message_queue_handler', $agent_slug ),
 	);
 
 	/**

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -159,6 +159,8 @@ add_action( 'rest_api_init', 'frontend_agent_chat_register_rest_routes' );
 function frontend_agent_chat_rest_bootstrap(): WP_REST_Response {
 	$had_principal = null !== frontend_agent_chat_get_browser_principal();
 	$principal     = frontend_agent_chat_ensure_browser_principal_cookie();
+	$config        = frontend_agent_chat_get_config();
+	$agent_slug    = frontend_agent_chat_get_default_agent_slug( $config );
 
 	return rest_ensure_response(
 		array(
@@ -170,7 +172,7 @@ function frontend_agent_chat_rest_bootstrap(): WP_REST_Response {
 				'browser_principal_id'      => is_array( $principal ) ? $principal['id'] : '',
 				'browser_principal_secret'  => false,
 				'session_persistence_scope' => is_user_logged_in() ? 'user' : 'browser',
-				'capabilities'              => frontend_agent_chat_get_run_control_capabilities(),
+				'capabilities'              => frontend_agent_chat_get_run_control_capabilities( $agent_slug ),
 			),
 		)
 	);

--- a/tests/run-control-smoke.php
+++ b/tests/run-control-smoke.php
@@ -120,8 +120,12 @@ function sanitize_key( $value ) {
 	return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) );
 }
 
-function apply_filters( $hook, $value ) {
-	unset( $hook );
+function apply_filters( $hook, $value, ...$args ) {
+	if ( isset( $GLOBALS['frontend_agent_chat_run_control_handlers'][ $hook ] ) ) {
+		$GLOBALS['frontend_agent_chat_run_control_handler_checks'][] = array( $hook, $args[0] ?? array() );
+		return $GLOBALS['frontend_agent_chat_run_control_handlers'][ $hook ];
+	}
+
 	return $value;
 }
 
@@ -188,8 +192,9 @@ function frontend_agent_chat_run_control_assert_equals( $expected, $actual, stri
 
 echo "frontend-agent-chat-run-control-smoke\n";
 
-$GLOBALS['frontend_agent_chat_run_control_calls']     = array();
-$GLOBALS['frontend_agent_chat_run_control_agents']    = array(
+$GLOBALS['frontend_agent_chat_run_control_calls']          = array();
+$GLOBALS['frontend_agent_chat_run_control_handler_checks'] = array();
+$GLOBALS['frontend_agent_chat_run_control_agents']         = array(
 	array(
 		'slug'        => 'demo-agent',
 		'label'       => 'Demo Agent',
@@ -203,13 +208,40 @@ $GLOBALS['frontend_agent_chat_run_control_abilities'] = array(
 	'agents/cancel-chat-run',
 	'agents/queue-chat-message',
 );
+$GLOBALS['frontend_agent_chat_run_control_handlers'] = array();
 
 $_COOKIE[ FRONTEND_AGENT_CHAT_BROWSER_COOKIE ] = str_repeat( 'b', 64 );
 
 $capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' );
-frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_status'], 'status capability follows ability availability', $failures, $passes );
-frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_cancel'], 'cancel capability follows ability availability', $failures, $passes );
-frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_message_queue'], 'queue capability follows ability availability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( false, $capabilities['chat_run_status'], 'status capability requires runtime handler', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( false, $capabilities['chat_run_cancel'], 'cancel capability requires runtime handler', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( false, $capabilities['chat_message_queue'], 'queue capability requires runtime handler', $failures, $passes );
+
+$GLOBALS['frontend_agent_chat_run_control_handlers'] = array(
+	'wp_agent_chat_run_status_handler'    => static fn( array $input ) => array(
+		'run_id'     => $input['run_id'],
+		'session_id' => $input['session_id'],
+		'status'     => 'running',
+	),
+	'wp_agent_chat_run_cancel_handler'    => static fn( array $input ) => array(
+		'run_id'     => $input['run_id'],
+		'session_id' => $input['session_id'],
+		'status'     => 'cancelling',
+		'cancelled'  => true,
+	),
+	'wp_agent_chat_message_queue_handler' => static fn( array $input ) => array(
+		'run_id'            => 'run-next',
+		'session_id'        => $input['session_id'],
+		'status'            => 'queued',
+		'queued_message_id' => 'queued-1',
+	),
+);
+
+$capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_status'], 'status capability requires ability and handler', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_cancel'], 'cancel capability requires ability and handler', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_message_queue'], 'queue capability requires ability and handler', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( 'demo-agent', $GLOBALS['frontend_agent_chat_run_control_handler_checks'][0][1]['agent'] ?? '', 'handler probe includes selected agent', $failures, $passes );
 
 $run_response = frontend_agent_chat_rest_get_run( new WP_REST_Request( array( 'run_id' => 'run-1', 'session_id' => 'session-1', 'agent' => 'demo-agent' ) ) );
 frontend_agent_chat_run_control_assert_equals( 'running', $run_response['data']['status'] ?? '', 'run status is normalized', $failures, $passes );

--- a/tests/run-control-smoke.php
+++ b/tests/run-control-smoke.php
@@ -68,6 +68,14 @@ class FrontendAgentChatRunControlFakeAbility {
 			return array( 'allowed' => true );
 		}
 
+		if ( 'agents/chat-run-control-capabilities' === $this->name ) {
+			return array(
+				'chat_run_status'    => isset( $GLOBALS['frontend_agent_chat_run_control_handlers']['wp_agent_chat_run_status_handler'] ),
+				'chat_run_cancel'    => isset( $GLOBALS['frontend_agent_chat_run_control_handlers']['wp_agent_chat_run_cancel_handler'] ),
+				'chat_message_queue' => isset( $GLOBALS['frontend_agent_chat_run_control_handlers']['wp_agent_chat_message_queue_handler'] ),
+			);
+		}
+
 		if ( 'agents/get-chat-run' === $this->name ) {
 			return array(
 				'run_id'     => $input['run_id'],
@@ -120,12 +128,8 @@ function sanitize_key( $value ) {
 	return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) );
 }
 
-function apply_filters( $hook, $value, ...$args ) {
-	if ( isset( $GLOBALS['frontend_agent_chat_run_control_handlers'][ $hook ] ) ) {
-		$GLOBALS['frontend_agent_chat_run_control_handler_checks'][] = array( $hook, $args[0] ?? array() );
-		return $GLOBALS['frontend_agent_chat_run_control_handlers'][ $hook ];
-	}
-
+function apply_filters( $hook, $value ) {
+	unset( $hook );
 	return $value;
 }
 
@@ -192,9 +196,8 @@ function frontend_agent_chat_run_control_assert_equals( $expected, $actual, stri
 
 echo "frontend-agent-chat-run-control-smoke\n";
 
-$GLOBALS['frontend_agent_chat_run_control_calls']          = array();
-$GLOBALS['frontend_agent_chat_run_control_handler_checks'] = array();
-$GLOBALS['frontend_agent_chat_run_control_agents']         = array(
+$GLOBALS['frontend_agent_chat_run_control_calls']  = array();
+$GLOBALS['frontend_agent_chat_run_control_agents'] = array(
 	array(
 		'slug'        => 'demo-agent',
 		'label'       => 'Demo Agent',
@@ -204,6 +207,7 @@ $GLOBALS['frontend_agent_chat_run_control_agents']         = array(
 $GLOBALS['frontend_agent_chat_run_control_abilities'] = array(
 	'agents/list-accessible-agents',
 	'agents/can-access-agent',
+	'agents/chat-run-control-capabilities',
 	'agents/get-chat-run',
 	'agents/cancel-chat-run',
 	'agents/queue-chat-message',
@@ -241,7 +245,8 @@ $capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' )
 frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_status'], 'status capability requires ability and handler', $failures, $passes );
 frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_cancel'], 'cancel capability requires ability and handler', $failures, $passes );
 frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_message_queue'], 'queue capability requires ability and handler', $failures, $passes );
-frontend_agent_chat_run_control_assert_equals( 'demo-agent', $GLOBALS['frontend_agent_chat_run_control_handler_checks'][0][1]['agent'] ?? '', 'handler probe includes selected agent', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( 'agents/chat-run-control-capabilities', $GLOBALS['frontend_agent_chat_run_control_calls'][2][0] ?? '', 'capability detection calls canonical probe ability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( 'demo-agent', $GLOBALS['frontend_agent_chat_run_control_calls'][2][1]['agent'] ?? '', 'capability probe receives selected agent', $failures, $passes );
 
 $run_response = frontend_agent_chat_rest_get_run( new WP_REST_Request( array( 'run_id' => 'run-1', 'session_id' => 'session-1', 'agent' => 'demo-agent' ) ) );
 frontend_agent_chat_run_control_assert_equals( 'running', $run_response['data']['status'] ?? '', 'run status is normalized', $failures, $passes );
@@ -259,7 +264,7 @@ frontend_agent_chat_run_control_assert_equals( 'run-1', $last_call[1]['run_id'] 
 
 $GLOBALS['frontend_agent_chat_run_control_abilities'] = array( 'agents/list-accessible-agents', 'agents/can-access-agent' );
 $capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' );
-frontend_agent_chat_run_control_assert_equals( false, $capabilities['chat_run_status'], 'missing upstream ability disables status capability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( false, $capabilities['chat_run_status'], 'missing capability probe disables status capability', $failures, $passes );
 
 if ( ! empty( $failures ) ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/run-control-smoke.php
+++ b/tests/run-control-smoke.php
@@ -68,14 +68,6 @@ class FrontendAgentChatRunControlFakeAbility {
 			return array( 'allowed' => true );
 		}
 
-		if ( 'agents/chat-run-control-capabilities' === $this->name ) {
-			return array(
-				'chat_run_status'    => isset( $GLOBALS['frontend_agent_chat_run_control_handlers']['wp_agent_chat_run_status_handler'] ),
-				'chat_run_cancel'    => isset( $GLOBALS['frontend_agent_chat_run_control_handlers']['wp_agent_chat_run_cancel_handler'] ),
-				'chat_message_queue' => isset( $GLOBALS['frontend_agent_chat_run_control_handlers']['wp_agent_chat_message_queue_handler'] ),
-			);
-		}
-
 		if ( 'agents/get-chat-run' === $this->name ) {
 			return array(
 				'run_id'     => $input['run_id'],
@@ -207,46 +199,18 @@ $GLOBALS['frontend_agent_chat_run_control_agents'] = array(
 $GLOBALS['frontend_agent_chat_run_control_abilities'] = array(
 	'agents/list-accessible-agents',
 	'agents/can-access-agent',
-	'agents/chat-run-control-capabilities',
 	'agents/get-chat-run',
 	'agents/cancel-chat-run',
 	'agents/queue-chat-message',
 );
-$GLOBALS['frontend_agent_chat_run_control_handlers'] = array();
 
 $_COOKIE[ FRONTEND_AGENT_CHAT_BROWSER_COOKIE ] = str_repeat( 'b', 64 );
 
 $capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' );
-frontend_agent_chat_run_control_assert_equals( false, $capabilities['chat_run_status'], 'status capability requires runtime handler', $failures, $passes );
-frontend_agent_chat_run_control_assert_equals( false, $capabilities['chat_run_cancel'], 'cancel capability requires runtime handler', $failures, $passes );
-frontend_agent_chat_run_control_assert_equals( false, $capabilities['chat_message_queue'], 'queue capability requires runtime handler', $failures, $passes );
-
-$GLOBALS['frontend_agent_chat_run_control_handlers'] = array(
-	'wp_agent_chat_run_status_handler'    => static fn( array $input ) => array(
-		'run_id'     => $input['run_id'],
-		'session_id' => $input['session_id'],
-		'status'     => 'running',
-	),
-	'wp_agent_chat_run_cancel_handler'    => static fn( array $input ) => array(
-		'run_id'     => $input['run_id'],
-		'session_id' => $input['session_id'],
-		'status'     => 'cancelling',
-		'cancelled'  => true,
-	),
-	'wp_agent_chat_message_queue_handler' => static fn( array $input ) => array(
-		'run_id'            => 'run-next',
-		'session_id'        => $input['session_id'],
-		'status'            => 'queued',
-		'queued_message_id' => 'queued-1',
-	),
-);
-
-$capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' );
-frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_status'], 'status capability requires ability and handler', $failures, $passes );
-frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_cancel'], 'cancel capability requires ability and handler', $failures, $passes );
-frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_message_queue'], 'queue capability requires ability and handler', $failures, $passes );
-frontend_agent_chat_run_control_assert_equals( 'agents/chat-run-control-capabilities', $GLOBALS['frontend_agent_chat_run_control_calls'][2][0] ?? '', 'capability detection calls canonical probe ability', $failures, $passes );
-frontend_agent_chat_run_control_assert_equals( 'demo-agent', $GLOBALS['frontend_agent_chat_run_control_calls'][2][1]['agent'] ?? '', 'capability probe receives selected agent', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_status'], 'status capability requires canonical ability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_cancel'], 'cancel capability requires canonical ability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_message_queue'], 'queue capability requires canonical ability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( 'agents/list-accessible-agents', $GLOBALS['frontend_agent_chat_run_control_calls'][0][0] ?? '', 'capability detection checks selected agent access', $failures, $passes );
 
 $run_response = frontend_agent_chat_rest_get_run( new WP_REST_Request( array( 'run_id' => 'run-1', 'session_id' => 'session-1', 'agent' => 'demo-agent' ) ) );
 frontend_agent_chat_run_control_assert_equals( 'running', $run_response['data']['status'] ?? '', 'run status is normalized', $failures, $passes );
@@ -264,7 +228,7 @@ frontend_agent_chat_run_control_assert_equals( 'run-1', $last_call[1]['run_id'] 
 
 $GLOBALS['frontend_agent_chat_run_control_abilities'] = array( 'agents/list-accessible-agents', 'agents/can-access-agent' );
 $capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' );
-frontend_agent_chat_run_control_assert_equals( false, $capabilities['chat_run_status'], 'missing capability probe disables status capability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( false, $capabilities['chat_run_status'], 'missing status ability disables status capability', $failures, $passes );
 
 if ( ! empty( $failures ) ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- Removes the runtime-handler capability probe dependency from frontend chat run-control detection.
- Enables status, Stop, and Queue controls when the canonical Agents API run-control abilities are registered and the selected agent is accessible.
- Keeps the existing filter so hosts can still narrow or override exposed controls when needed.

## Verification
- `git diff --check`
- `php tests/run-control-smoke.php`
- `php -l inc/config.php && php -l tests/run-control-smoke.php`
- `npm run typecheck`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Revised run-control detection and smoke coverage to match the default Agents API run-control model, then ran validation. Chris remains responsible for review and merge.