### PR TITLE
Bootstrap browser sessions before chat mount

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -503,6 +503,7 @@ export default function AgentChat( {
 	const persistenceMessage = browserBootstrapFailed
 		? __( 'Chat works, but this browser is blocking secure chat-history cookies.', 'frontend-agent-chat' )
 		: persistenceCta?.message;
+	const chatStorageReady = isLoggedIn || browserBootstrapReady;
 	const expandedButtonLabel = isExpanded
 		? __( 'Exit expanded chat view', 'frontend-agent-chat' )
 		: __( 'Expand chat to viewport', 'frontend-agent-chat' );
@@ -607,12 +608,12 @@ export default function AgentChat( {
 						persistenceCta.actionLabel
 					)
 				),
-				activeAgentSlug && createElement( Chat, {
+				activeAgentSlug && chatStorageReady && createElement( Chat, {
 					key: activeAgentSlug,
 					basePath,
 					fetchFn: agentFetch,
 					showTools: true,
-					showSessions: isLoggedIn || browserBootstrapReady,
+					showSessions: true,
 					toolRenderers,
 					placeholder: sprintf(
 						/* translators: %s: agent name. */


### PR DESCRIPTION
## Summary
- Delays mounting the underlying chat component until the anonymous browser-principal bootstrap completes.
- Prevents the chat hook from calling `agents/list-conversation-sessions` before the browser owner cookie exists.
- Removes the initial frontend sessions `500` while preserving session history once bootstrap is ready.

## Verification
- `npm run typecheck`
- Deployed to `studioweb-runtime`.
- Fresh browser load showed bootstrap `200`, agents `200`, bootstrap verification `200`, then sessions `200` with no sessions `500`.
- Follow-up Studio Web generation reached `WordPress preview ready`; sessions requests were `200, 200`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the premature sessions request and drafting the mount gating fix, with runtime verification.