### PR TITLE
fix: clarify site generator tool card and restore sessions

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,7 +1,8 @@
 {
-  "id": "frontend-agent-chat",
-  "changelog_target": "docs/CHANGELOG.md",
-  "remote_path": "wp-content/plugins/frontend-agent-chat",
+	"id": "frontend-agent-chat",
+	"changelog_target": "docs/CHANGELOG.md",
+	"extract_command": "tmp=$(mktemp -d) && unzip -q {artifact} -d $tmp && cp -a $tmp/frontend-agent-chat/. . && rm -rf $tmp {artifact}",
+	"remote_path": "wp-content/plugins/frontend-agent-chat",
   "extensions": {
     "wordpress": {}
   },

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -660,8 +660,14 @@ function frontend_agent_chat_rest_list_sessions( WP_REST_Request $request ) {
  * @return WP_REST_Response|WP_Error
  */
 function frontend_agent_chat_rest_get_session( WP_REST_Request $request ) {
+	$config     = frontend_agent_chat_get_config();
+	$agent_slug = frontend_agent_chat_rest_get_agent_slug( $request, frontend_agent_chat_get_default_agent_slug( $config ) );
 	$session_id = sanitize_text_field( (string) $request['session_id'] );
-	$result     = frontend_agent_chat_execute_ability( 'agents/get-conversation-session', frontend_agent_chat_add_browser_principal_input( array( 'session_id' => $session_id ) ) );
+	$input      = array( 'session_id' => $session_id );
+	if ( '' !== $agent_slug ) {
+		$input['agent'] = $agent_slug;
+	}
+	$result = frontend_agent_chat_execute_ability( 'agents/get-conversation-session', frontend_agent_chat_add_browser_principal_input( $input ) );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -686,8 +692,14 @@ function frontend_agent_chat_rest_get_session( WP_REST_Request $request ) {
  * @return WP_REST_Response|WP_Error
  */
 function frontend_agent_chat_rest_delete_session( WP_REST_Request $request ) {
+	$config     = frontend_agent_chat_get_config();
+	$agent_slug = frontend_agent_chat_rest_get_agent_slug( $request, frontend_agent_chat_get_default_agent_slug( $config ) );
 	$session_id = sanitize_text_field( (string) $request['session_id'] );
-	$result     = frontend_agent_chat_execute_ability( 'agents/delete-conversation-session', frontend_agent_chat_add_browser_principal_input( array( 'session_id' => $session_id ) ) );
+	$input      = array( 'session_id' => $session_id );
+	if ( '' !== $agent_slug ) {
+		$input['agent'] = $agent_slug;
+	}
+	$result = frontend_agent_chat_execute_ability( 'agents/delete-conversation-session', frontend_agent_chat_add_browser_principal_input( $input ) );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -385,18 +385,56 @@ function renderQuestionCard( group: ToolGroup, context: ToolRendererContext ): R
 	} );
 }
 
+function generationErrorMessage( group: ToolGroup ): string {
+	const content = group.resultMessage?.content?.trim();
+	if ( ! content ) {
+		return __( 'The site generator could not be started. Try again or adjust the request.', 'frontend-agent-chat' );
+	}
+
+	try {
+		const parsed = JSON.parse( content ) as unknown;
+		if ( parsed && typeof parsed === 'object' && ! Array.isArray( parsed ) ) {
+			const record = parsed as Record<string, unknown>;
+			const error = record.error;
+			if ( typeof error === 'string' && error.trim() ) {
+				return error.trim();
+			}
+
+			if ( error && typeof error === 'object' && ! Array.isArray( error ) ) {
+				const message = ( error as Record<string, unknown> ).message;
+				if ( typeof message === 'string' && message.trim() ) {
+					return message.trim();
+				}
+			}
+
+			const message = record.message;
+			if ( typeof message === 'string' && message.trim() ) {
+				return message.trim();
+			}
+		}
+	} catch {
+		// Tool results are often plain text. Use the raw content below.
+	}
+
+	return content;
+}
+
 function renderGenerationCard( group: ToolGroup ): ReactNode {
+	const hasError = group.success === false;
+	const errorMessage = hasError ? generationErrorMessage( group ) : '';
+
 	return createElement(
 		'div',
-		{ className: `frontend-agent-chat__tool-card frontend-agent-chat__tool-card--generation${ group.success === false ? ' has-error' : '' }` },
-		createElement( 'div', { className: 'frontend-agent-chat__tool-card-title' }, __( 'WordPress preview', 'frontend-agent-chat' ) ),
+		{ className: `frontend-agent-chat__tool-card frontend-agent-chat__tool-card--generation${ hasError ? ' has-error' : '' }` },
+		createElement( 'div', { className: 'frontend-agent-chat__tool-card-title' }, __( 'WordPress Site Generator', 'frontend-agent-chat' ) ),
 		createElement(
 			'p',
 			{ className: 'frontend-agent-chat__tool-card-copy' },
-			group.success === false
-				? __( 'The preview could not be started. Try again with a shorter brief or adjust the request.', 'frontend-agent-chat' )
-				: __( 'Studio Web is preparing your WordPress preview from the captured site brief.', 'frontend-agent-chat' )
-		)
+			hasError
+				? __( 'The WordPress site generator could not be started.', 'frontend-agent-chat' )
+				: __( 'Studio Web is preparing your WordPress site from the captured site brief.', 'frontend-agent-chat' )
+		),
+		hasError && createElement( 'p', { className: 'frontend-agent-chat__tool-card-error' }, errorMessage )
 	);
 }
 

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -334,6 +334,10 @@
 	background: var(--frontend-agent-chat-error-bg, #fef2f2);
 }
 
+.frontend-agent-chat__tool-card--generation.has-error {
+	box-shadow: 0 8px 24px rgba(127, 29, 29, 0.12);
+}
+
 .frontend-agent-chat__tool-card-title {
 	margin-bottom: 4px;
 	font-weight: 700;
@@ -344,6 +348,18 @@
 	color: var(--frontend-agent-chat-text-muted, #64748b);
 	font-size: 13px;
 	line-height: 1.45;
+}
+
+.frontend-agent-chat__tool-card-error {
+	margin: 8px 0 0;
+	padding: 8px 10px;
+	border-radius: 10px;
+	background: var(--frontend-agent-chat-error-detail-bg, rgba(127, 29, 29, 0.08));
+	color: var(--frontend-agent-chat-error-text, #991b1b);
+	font-family: var(--frontend-agent-chat-monospace-font-family, ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', monospace);
+	font-size: 12px;
+	line-height: 1.45;
+	white-space: pre-wrap;
 }
 
 .frontend-agent-chat__empty {


### PR DESCRIPTION
## Summary
- Rename the Studio Web generation tool card from `WordPress preview` to `WordPress Site Generator`.
- Show the actual tool error text in the custom generation card instead of only generic failure copy.
- Preserve the selected agent when restoring or deleting browser chat sessions so anonymous session permissions can read saved transcripts.

## Testing
- `npm run typecheck`
- `npm run build`
- `php tests/principal-access-smoke.php`
- `php tests/run-control-smoke.php`

## Context
The latest Studio Web generation attempt failed with `Browser plugin URL host is not allowed`, but the custom tool card hid that useful error and used the less accurate `WordPress preview` label. Runtime inspection also showed the Pickle Brigade chat transcript was saved, while restore could fail because read/delete routes omitted the agent required by browser-principal session permissions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the Studio Web transcript and custom tool renderer, updated the card label/error presentation, fixed the anonymous session restore input, and ran verification.