### PR TITLE
Remove Data Machine agent preference coupling

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -106,7 +106,7 @@ function frontend_agent_chat_list_accessible_agents(): array {
 }
 
 /**
- * Read the current user's active Data Machine agent preference when available.
+ * Read the current user's active agent preference.
  *
  * @return string Active agent slug or empty string.
  */
@@ -116,12 +116,7 @@ function frontend_agent_chat_get_active_agent_slug(): string {
 		return sanitize_title( (string) ( $preferences['active_agent_slug'] ?? '' ) );
 	}
 
-	$result = frontend_agent_chat_execute_ability( 'datamachine/get-active-agent', array() );
-	if ( is_wp_error( $result ) || ! is_array( $result ) || empty( $result['success'] ) ) {
-		return '';
-	}
-
-	return sanitize_title( (string) ( $result['agent_slug'] ?? '' ) );
+	return sanitize_title( (string) get_user_meta( get_current_user_id(), 'frontend_agent_chat_active_agent_slug', true ) );
 }
 
 /**
@@ -150,8 +145,6 @@ function frontend_agent_chat_get_default_agent_slug( ?array $config = null ): st
 /**
  * Persist an anonymous browser preference keyed by the browser principal.
  *
- * Logged-in users keep using Data Machine's normal user-owned preference.
- *
  * @param string $agent_slug Active agent slug.
  * @return bool Whether the preference was stored.
  */
@@ -170,6 +163,21 @@ function frontend_agent_chat_set_browser_active_agent_slug( string $agent_slug )
 		array( 'active_agent_slug' => sanitize_title( $agent_slug ) ),
 		false
 	);
+}
+
+/**
+ * Persist the current user's active agent preference.
+ *
+ * @param string $agent_slug Active agent slug.
+ * @return bool Whether the preference was stored.
+ */
+function frontend_agent_chat_set_user_active_agent_slug( string $agent_slug ): bool {
+	$user_id = get_current_user_id();
+	if ( $user_id <= 0 ) {
+		return false;
+	}
+
+	return false !== update_user_meta( $user_id, 'frontend_agent_chat_active_agent_slug', sanitize_title( $agent_slug ) );
 }
 
 /**

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -229,7 +229,7 @@ function frontend_agent_chat_rest_list_agents(): WP_REST_Response {
 }
 
 /**
- * Get the current user's active Data Machine agent preference.
+ * Get the current user's active agent preference.
  *
  * @return WP_REST_Response
  */
@@ -245,7 +245,7 @@ function frontend_agent_chat_rest_get_active_agent(): WP_REST_Response {
 }
 
 /**
- * Persist the current user's active Data Machine agent preference.
+ * Persist the current user's active agent preference.
  *
  * @param WP_REST_Request $request REST request.
  * @return WP_REST_Response|WP_Error
@@ -275,19 +275,15 @@ function frontend_agent_chat_rest_set_active_agent( WP_REST_Request $request ) {
 		);
 	}
 
-	$result = frontend_agent_chat_execute_ability( 'datamachine/set-active-agent', array( 'agent' => $agent_slug ) );
-	if ( is_wp_error( $result ) ) {
-		return $result;
-	}
-	if ( empty( $result['success'] ) ) {
-		return new WP_Error( 'frontend_agent_chat_active_agent_failed', (string) ( $result['error'] ?? __( 'Failed to set active agent.', 'frontend-agent-chat' ) ), array( 'status' => 400 ) );
+	if ( ! frontend_agent_chat_set_user_active_agent_slug( $agent_slug ) ) {
+		return new WP_Error( 'frontend_agent_chat_active_agent_failed', __( 'Failed to set active agent.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
 	}
 
 	return rest_ensure_response(
 		array(
 			'success' => true,
 			'data'    => array(
-				'agent_slug' => sanitize_title( (string) ( $result['agent_slug'] ?? $agent_slug ) ),
+				'agent_slug' => $agent_slug,
 			),
 		)
 	);
@@ -362,8 +358,8 @@ function frontend_agent_chat_rest_send_message( WP_REST_Request $request ) {
 	/**
 	 * Filter the canonical agents/chat input sent by the frontend chat widget.
 	 *
-	 * Domain plugins can use this to add runtime context, such as a Data Machine
-	 * execution mode, without hardcoding product-specific behavior here.
+	 * Domain plugins can use this to add runtime context without hardcoding
+	 * product-specific behavior here.
 	 *
 	 * @param array           $chat_input Canonical agents/chat input.
 	 * @param WP_REST_Request $request    REST request.


### PR DESCRIPTION
## Summary
- Store active-agent preferences in frontend-agent-chat-owned user meta instead of Data Machine abilities.
- Keep chat execution on the canonical Agents API abilities.
- Remove Data Machine-specific comments from the runtime REST adapter.

## Testing
- `npm run build`
- `npm run typecheck`
- `php -l inc/config.php`
- `php -l inc/rest.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Removed Data Machine coupling from frontend-agent-chat active-agent preference handling and verified the plugin build/typecheck.