### PR TITLE
Remove redundant question-card freeform input

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -377,7 +377,7 @@ function renderQuestionCard( group: ToolGroup, context: ToolRendererContext ): R
 	return createElement( QuestionCard, {
 		question: payload.question ?? '',
 		choices: payload.choices,
-		allowFreeform: payload.allow_freeform,
+		allowFreeform: false,
 		freeformLabel: payload.freeform_label,
 		freeformPlaceholder: payload.freeform_placeholder,
 		disabled: context.isLoading,


### PR DESCRIPTION
## Summary
- Render Studio Web question cards without the embedded freeform response input.
- Keep choices clickable while preserving the main chat composer as the freeform answer path.

## Testing
- npm run typecheck
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the question-card rendering path, made the one-line change, and ran verification commands.