### PR TITLE
Consume canonical chat run events

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -464,7 +464,7 @@ function frontend_agent_chat_has_ability( string $name ): bool {
  * Detect run-control support for the current frontend chat principal.
  *
  * @param string $agent_slug Optional selected agent slug.
- * @return array{chat_run_status:bool,chat_run_cancel:bool,chat_message_queue:bool}
+ * @return array{chat_run_status:bool,chat_run_cancel:bool,chat_message_queue:bool,chat_run_events:bool}
  */
 function frontend_agent_chat_get_run_control_capabilities( string $agent_slug = '' ): array {
 	$agent_slug = sanitize_title( $agent_slug );
@@ -478,6 +478,7 @@ function frontend_agent_chat_get_run_control_capabilities( string $agent_slug = 
 		'chat_run_status'    => $can_chat && frontend_agent_chat_has_ability( 'agents/get-chat-run' ),
 		'chat_run_cancel'    => $can_chat && frontend_agent_chat_has_ability( 'agents/cancel-chat-run' ),
 		'chat_message_queue' => $can_chat && frontend_agent_chat_has_ability( 'agents/queue-chat-message' ),
+		'chat_run_events'    => $can_chat && frontend_agent_chat_has_ability( 'agents/list-chat-run-events' ),
 	);
 
 	/**
@@ -493,6 +494,7 @@ function frontend_agent_chat_get_run_control_capabilities( string $agent_slug = 
 		'chat_run_status'    => ! empty( $filtered['chat_run_status'] ),
 		'chat_run_cancel'    => ! empty( $filtered['chat_run_cancel'] ),
 		'chat_message_queue' => ! empty( $filtered['chat_message_queue'] ),
+		'chat_run_events'    => ! empty( $filtered['chat_run_events'] ),
 	) : $capabilities;
 }
 

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -84,6 +84,16 @@ function frontend_agent_chat_register_rest_routes(): void {
 
 	register_rest_route(
 		'frontend-agent-chat/v1',
+		'/chat/runs/(?P<run_id>[^/]+)/events',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'frontend_agent_chat_rest_list_run_events',
+			'permission_callback' => 'frontend_agent_chat_rest_can_chat',
+		)
+	);
+
+	register_rest_route(
+		'frontend-agent-chat/v1',
 		'/chat/runs/(?P<run_id>[^/]+)/cancel',
 		array(
 			'methods'             => WP_REST_Server::CREATABLE,
@@ -377,18 +387,24 @@ function frontend_agent_chat_rest_send_message( WP_REST_Request $request ) {
 	}
 
 	$result_session_id = sanitize_text_field( (string) ( $result['session_id'] ?? $session_id ) );
+	$result_run_id     = sanitize_text_field( (string) ( $result['run_id'] ?? '' ) );
 	$conversation      = frontend_agent_chat_normalize_result_messages( $result, $message );
+	$metadata          = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
+	if ( '' !== $result_run_id ) {
+		$metadata['run_id']     = $result_run_id;
+		$metadata['session_id'] = $result_session_id;
+	}
 
 	return rest_ensure_response(
 		array(
 			'success' => true,
 			'data'    => array(
 				'session_id'        => $result_session_id,
-				'run_id'            => sanitize_text_field( (string) ( $result['run_id'] ?? '' ) ),
+				'run_id'            => $result_run_id,
 				'response'          => (string) ( $result['reply'] ?? '' ),
 				'tool_calls'        => is_array( $result['tool_calls'] ?? null ) ? $result['tool_calls'] : array(),
 				'conversation'      => $conversation,
-				'metadata'          => is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array(),
+				'metadata'          => $metadata,
 				'completed'         => (bool) ( $result['completed'] ?? true ),
 				'max_turns'         => 1,
 				'turn_number'       => 1,
@@ -428,6 +444,47 @@ function frontend_agent_chat_rest_get_run( WP_REST_Request $request ) {
 		array(
 			'success' => true,
 			'data'    => frontend_agent_chat_normalize_run_control_result( is_array( $result ) ? $result : array(), $run_id, $session_id ),
+		)
+	);
+}
+
+/**
+ * List canonical Agents API chat run events.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function frontend_agent_chat_rest_list_run_events( WP_REST_Request $request ) {
+	$run_id     = sanitize_text_field( (string) $request['run_id'] );
+	$session_id = sanitize_text_field( (string) $request->get_param( 'session_id' ) );
+	if ( '' === $run_id || '' === $session_id ) {
+		return new WP_Error( 'frontend_agent_chat_invalid_run', __( 'run_id and session_id are required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+	}
+
+	$limit = (int) $request->get_param( 'limit' );
+	if ( $limit <= 0 ) {
+		$limit = 100;
+	}
+
+	$result = frontend_agent_chat_execute_ability(
+		'agents/list-chat-run-events',
+		frontend_agent_chat_add_browser_principal_input(
+			array(
+				'run_id'     => $run_id,
+				'session_id' => $session_id,
+				'cursor'     => sanitize_text_field( (string) $request->get_param( 'cursor' ) ),
+				'limit'      => max( 1, min( 1000, $limit ) ),
+			)
+		)
+	);
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response(
+		array(
+			'success' => true,
+			'data'    => frontend_agent_chat_normalize_run_events_result( is_array( $result ) ? $result : array(), $run_id, $session_id ),
 		)
 	);
 }
@@ -744,6 +801,40 @@ function frontend_agent_chat_normalize_run_control_result( array $result, string
 		'started_at' => sanitize_text_field( (string) ( $result['started_at'] ?? '' ) ),
 		'updated_at' => sanitize_text_field( (string) ( $result['updated_at'] ?? '' ) ),
 		'metadata'   => is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array(),
+	);
+}
+
+/**
+ * Normalize canonical chat run-event ability output for REST clients.
+ *
+ * @param array  $result     Ability result.
+ * @param string $run_id     Fallback run id.
+ * @param string $session_id Fallback session id.
+ * @return array
+ */
+function frontend_agent_chat_normalize_run_events_result( array $result, string $run_id, string $session_id ): array {
+	$events = array();
+	foreach ( is_array( $result['events'] ?? null ) ? $result['events'] : array() as $event ) {
+		if ( ! is_array( $event ) ) {
+			continue;
+		}
+
+		$events[] = array(
+			'id'         => sanitize_text_field( (string) ( $event['id'] ?? '' ) ),
+			'type'       => sanitize_key( (string) ( $event['type'] ?? '' ) ),
+			'message'    => sanitize_text_field( (string) ( $event['message'] ?? '' ) ),
+			'created_at' => sanitize_text_field( (string) ( $event['created_at'] ?? '' ) ),
+			'metadata'   => is_array( $event['metadata'] ?? null ) ? $event['metadata'] : array(),
+		);
+	}
+
+	return array(
+		'run_id'     => sanitize_text_field( (string) ( $result['run_id'] ?? $run_id ) ),
+		'session_id' => sanitize_text_field( (string) ( $result['session_id'] ?? $session_id ) ),
+		'status'     => sanitize_key( (string) ( $result['status'] ?? '' ) ),
+		'events'     => $events,
+		'cursor'     => sanitize_text_field( (string) ( $result['cursor'] ?? '' ) ),
+		'has_more'   => (bool) ( $result['has_more'] ?? false ),
 	);
 }
 

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -65,6 +65,7 @@ interface AgentChatProps {
 		chat_run_status?: boolean;
 		chat_run_cancel?: boolean;
 		chat_message_queue?: boolean;
+		chat_run_events?: boolean;
 	};
 }
 
@@ -90,6 +91,26 @@ interface RunControlResponse {
 		metadata?: Record< string, unknown >;
 		queued_message_id?: string;
 		position?: number;
+	};
+}
+
+interface ChatRunEvent {
+	id: string;
+	type: string;
+	message?: string;
+	created_at?: string;
+	metadata?: Record< string, unknown >;
+}
+
+interface RunEventsResponse {
+	success?: boolean;
+	data?: {
+		run_id?: string;
+		session_id?: string;
+		status?: string;
+		events?: ChatRunEvent[];
+		cursor?: string;
+		has_more?: boolean;
 	};
 }
 
@@ -268,6 +289,50 @@ function dispatchLifecycleEvent( phase: string, detail: Record< string, unknown 
 			},
 		} )
 	);
+}
+
+function dispatchRunEvent( event: ChatRunEvent, detail: Record< string, unknown > = {} ): void {
+	window.dispatchEvent(
+		new CustomEvent( 'frontend-agent-chat:run-event', {
+			detail: {
+				event,
+				...detail,
+			},
+		} )
+	);
+	dispatchLifecycleEvent( `run:${ event.type }`, {
+		...detail,
+		event,
+	} );
+}
+
+async function dispatchRunEvents( fetchFn: FetchFn, basePath: string, metadata: Record< string, unknown > ): Promise< void > {
+	const runId = metadata.run_id ?? metadata.runId;
+	const sessionId = metadata.session_id ?? metadata.sessionId;
+	if ( typeof runId !== 'string' || ! runId || typeof sessionId !== 'string' || ! sessionId ) {
+		return;
+	}
+
+	let cursor = '0';
+	let hasMore = true;
+	while ( hasMore ) {
+		const separator = `${ basePath }/runs/${ encodeURIComponent( runId ) }/events`.includes( '?' ) ? '&' : '?';
+		const response = await fetchFn( {
+			path: `${ basePath }/runs/${ encodeURIComponent( runId ) }/events${ separator }session_id=${ encodeURIComponent( sessionId ) }&cursor=${ encodeURIComponent( cursor ) }`,
+		} ) as RunEventsResponse;
+		const data = response.data ?? {};
+		for ( const event of data.events ?? [] ) {
+			dispatchRunEvent( event, {
+				run_id: runId,
+				session_id: sessionId,
+				status: data.status,
+			} );
+		}
+
+		const nextCursor = data.cursor ?? cursor;
+		hasMore = !! data.has_more && nextCursor !== cursor;
+		cursor = nextCursor;
+	}
 }
 
 /**
@@ -564,7 +629,13 @@ export default function AgentChat( {
 			metadata: responseMetadata,
 		} );
 		dispatchResponseMetadata( responseMetadata );
-	}, [ activeAgentSlug ] );
+		if ( capabilities?.chat_run_events ) {
+			dispatchRunEvents( agentFetch, basePath, responseMetadata ).catch( ( err: unknown ) => {
+				// eslint-disable-next-line no-console
+				console.error( 'AgentChat: failed to fetch chat run events', err );
+			} );
+		}
+	}, [ activeAgentSlug, agentFetch, basePath, capabilities?.chat_run_events ] );
 
 	useEffect( () => {
 		if ( isInline ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ declare global {
 				chat_run_status?: boolean;
 				chat_run_cancel?: boolean;
 				chat_message_queue?: boolean;
+				chat_run_events?: boolean;
 			};
 		};
 	}

--- a/tests/run-control-smoke.php
+++ b/tests/run-control-smoke.php
@@ -87,6 +87,24 @@ class FrontendAgentChatRunControlFakeAbility {
 			);
 		}
 
+		if ( 'agents/list-chat-run-events' === $this->name ) {
+			return array(
+				'run_id'     => $input['run_id'],
+				'session_id' => $input['session_id'],
+				'status'     => 'running',
+				'events'     => array(
+					array(
+						'id'         => '1',
+						'type'       => 'turn_started',
+						'created_at' => '2026-05-29T00:00:00Z',
+						'metadata'   => array( 'turn' => 1 ),
+					),
+				),
+				'cursor'     => '1',
+				'has_more'   => false,
+			);
+		}
+
 		if ( 'agents/queue-chat-message' === $this->name ) {
 			return array(
 				'queued_message_id' => 'queued-1',
@@ -200,6 +218,7 @@ $GLOBALS['frontend_agent_chat_run_control_abilities'] = array(
 	'agents/list-accessible-agents',
 	'agents/can-access-agent',
 	'agents/get-chat-run',
+	'agents/list-chat-run-events',
 	'agents/cancel-chat-run',
 	'agents/queue-chat-message',
 );
@@ -210,10 +229,14 @@ $capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' )
 frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_status'], 'status capability requires canonical ability', $failures, $passes );
 frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_cancel'], 'cancel capability requires canonical ability', $failures, $passes );
 frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_message_queue'], 'queue capability requires canonical ability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_events'], 'events capability requires canonical ability', $failures, $passes );
 frontend_agent_chat_run_control_assert_equals( 'agents/list-accessible-agents', $GLOBALS['frontend_agent_chat_run_control_calls'][0][0] ?? '', 'capability detection checks selected agent access', $failures, $passes );
 
 $run_response = frontend_agent_chat_rest_get_run( new WP_REST_Request( array( 'run_id' => 'run-1', 'session_id' => 'session-1', 'agent' => 'demo-agent' ) ) );
 frontend_agent_chat_run_control_assert_equals( 'running', $run_response['data']['status'] ?? '', 'run status is normalized', $failures, $passes );
+
+$events_response = frontend_agent_chat_rest_list_run_events( new WP_REST_Request( array( 'run_id' => 'run-1', 'session_id' => 'session-1', 'agent' => 'demo-agent', 'cursor' => '0' ) ) );
+frontend_agent_chat_run_control_assert_equals( 'turn_started', $events_response['data']['events'][0]['type'] ?? '', 'run events are normalized', $failures, $passes );
 
 $cancel_response = frontend_agent_chat_rest_cancel_run( new WP_REST_Request( array( 'run_id' => 'run-1', 'session_id' => 'session-1', 'agent' => 'demo-agent' ) ) );
 frontend_agent_chat_run_control_assert_equals( true, $cancel_response['data']['cancelled'] ?? false, 'cancel response is normalized', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add a frontend REST adapter for `agents/list-chat-run-events`.
- Expose a `chat_run_events` capability and include run/session identifiers in response metadata.
- Dispatch canonical run events from the React wrapper for downstream product UIs.

## Testing
- `php -l inc/rest.php && php -l inc/config.php`
- `php tests/run-control-smoke.php`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and verification steps; Chris remains responsible for review and testing.