### PR TITLE
build: bump @extrachill/chat to v0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat#b1d862f67abb5b98bd56a4e8d9d532c83b1050d2"
+				"@extrachill/chat": "github:Extra-Chill/chat#v0.13.0"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2656,16 +2656,15 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.12.4",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#b1d862f67abb5b98bd56a4e8d9d532c83b1050d2",
-			"integrity": "sha512-IQ+2ML3JFi3vwHZ0LjU/86gHYPrTakykHyM/wFq33weOShnNSNIZGoaWHNSY/c65+oWJI8eNP1oQycGZh4h71w==",
+			"version": "0.13.0",
+			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#51389ced7d6996740d5c3e512641390806707a33",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"
 			},
 			"peerDependencies": {
-				"react": ">=18.0.0",
-				"react-dom": ">=18.0.0"
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@floating-ui/core": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat#b1d862f67abb5b98bd56a4e8d9d532c83b1050d2"
+		"@extrachill/chat": "github:Extra-Chill/chat#v0.13.0"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",


### PR DESCRIPTION
## Summary
- Bump the `@extrachill/chat` dependency pin to the **v0.13.0** release tag.
- Previously pinned to an unreleased `main` commit SHA (`b1d862f`); now pinned to the clean release tag `#v0.13.0`.
- Lockfile updated to resolve the v0.13.0 release commit (`51389ce`), installed package version `0.13.0`.

## What v0.13.0 brings
- Explicit **React 19** support (widened peer ranges, React 19 type fix)
- Chat message suggestions
- Question tool cards
- Response metadata callbacks
- Long-running turn controls

## Verification
- `npm run build` (wp-scripts) compiles cleanly against v0.13.0.
- npm `latest` for `@extrachill/chat` is now `0.13.0` (published via homeboy release).

## Context
chat v0.13.0 was just merged + released + published to npm. This closes the last loose thread so the frontend chat widget picks up the new release instead of trailing an unreleased SHA.