### PR TITLE
feat: forward current page url to chat REST requests

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -198,6 +198,32 @@ function resolvePendingAction( actionId: string, decision: 'accepted' | 'rejecte
 	} );
 }
 
+/**
+ * Capture the page the widget is currently rendered on.
+ *
+ * Forwarded on POST requests so the backend can supply real page/location
+ * context to the agent. This is intentionally generic: the widget only knows
+ * "the current page" — it carries no product- or runtime-specific knowledge.
+ * Domain plugins decide what to do with it (e.g. compose client context).
+ *
+ * @return Page context fields, or an empty object when unavailable.
+ */
+function getPageContext(): Record< string, string > {
+	if ( typeof window === 'undefined' || ! window.location ) {
+		return {};
+	}
+
+	const context: Record< string, string > = {
+		page_url: window.location.href,
+	};
+
+	if ( typeof document !== 'undefined' && document.title ) {
+		context.page_title = document.title;
+	}
+
+	return context;
+}
+
 function createAgentFetch( agentSlug: string ): FetchFn {
 	return ( options ) => {
 		const method = options.method ?? 'GET';
@@ -209,7 +235,7 @@ function createAgentFetch( agentSlug: string ): FetchFn {
 				: options.path,
 			method: options.method,
 			data: method === 'POST'
-				? { ...( options.data ?? {} ), agent: agentSlug }
+				? { ...getPageContext(), ...( options.data ?? {} ), agent: agentSlug }
 				: options.data,
 			headers: options.headers,
 		} );


### PR DESCRIPTION
## Summary
- Forward the current `page_url` (and `page_title`) in the widget's POST request bodies via the shared `createAgentFetch` wrapper, so it lands on both the **send** (`/chat`) and **queue** (`/chat/queue`) paths.
- The widget previously sent no page/location context, so backends had no way to tell an agent which page the user opened the chat from.

## Why
Domain plugins need real page/location context to give agents accurate location awareness. The generic `frontend_agent_chat_chat_input` / `frontend_agent_chat_queue_input` filters already let a domain plugin enrich the chat input — but only if the page URL actually reaches the REST request. Before this change it didn't.

## Layer purity
This stays **runtime-agnostic**: the widget only knows "the current page" and carries no product- or runtime-specific knowledge. It just forwards `window.location.href` + `document.title`. Domain plugins decide what to do with it (e.g. compose `client_context` for an agent mode). No roadie/EC knowledge in FAC.

## Implementation
- New `getPageContext()` helper reads `window.location.href` and `document.title`, guarded for non-browser contexts.
- Spread into POST bodies in `createAgentFetch` **before** `options.data`, so any explicit caller data still wins; non-destructive.

## Verification
- `tsc --noEmit` passes.
- `wp-scripts build` compiles successfully.
- Consumed by extrachill-roadie PR (Extra-Chill/extrachill-roadie#30 fix branch) which reads `page_url` from the request and composes `client_context`.