### PR TITLE
feat: add present_question generic question-card renderer key

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -1066,6 +1066,7 @@ export default function AgentChat( {
 			edit_post_blocks: renderDiffCard,
 			replace_post_blocks: renderDiffCard,
 			insert_content: renderDiffCard,
+			present_question: renderQuestionCard,
 			studio_web_propose_questions: renderQuestionCard,
 			studio_web_start_generation: renderGenerationCard,
 		} ),


### PR DESCRIPTION
## Summary
- Maps the generic `present_question` tool name to the existing tool-name-agnostic `renderQuestionCard` renderer in the `toolRenderers` map.
- The existing `studio_web_propose_questions` mapping is preserved (unchanged).
- This lets any agent surface (e.g. roadie) render a multiple-choice question card simply by calling a tool named `present_question` whose result is `{ "result": { "question": "...", "choices": [ {"label","message","description?"} ] } }`. Clicking a choice sends `choice.message` back as a normal user turn.

## Verification
- `npm run build` succeeds (build artifacts committed).

Part of #31