### PR TITLE
fix: remove Studio Web renderer coupling

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -142,7 +142,7 @@ interface AgentsResponse {
 	};
 }
 
-type ArtifactPhaseStatus = 'pending' | 'running' | 'completed' | 'failed' | 'retrying';
+type ArtifactPhaseStatus = 'pending' | 'running' | 'ready' | 'completed' | 'failed' | 'retrying';
 
 interface ArtifactThumbnail {
 	url: string;
@@ -478,7 +478,7 @@ function normalizeArtifactStatus( status: unknown ): ArtifactPhaseStatus | null 
 	}
 
 	const normalized = status.trim().toLowerCase();
-	if ( [ 'pending', 'running', 'completed', 'failed', 'retrying' ].includes( normalized ) ) {
+	if ( [ 'pending', 'running', 'ready', 'completed', 'failed', 'retrying' ].includes( normalized ) ) {
 		return normalized as ArtifactPhaseStatus;
 	}
 
@@ -714,65 +714,14 @@ function renderQuestionCard( group: ToolGroup, context: ToolRendererContext ): R
 	} );
 }
 
-function generationErrorMessage( group: ToolGroup ): string {
-	const content = group.resultMessage?.content?.trim();
-	if ( ! content ) {
-		return __( 'The site generator could not be started. Try again or adjust the request.', 'frontend-agent-chat' );
-	}
-
-	try {
-		const parsed = JSON.parse( content ) as unknown;
-		if ( parsed && typeof parsed === 'object' && ! Array.isArray( parsed ) ) {
-			const record = parsed as Record<string, unknown>;
-			const error = record.error;
-			if ( typeof error === 'string' && error.trim() ) {
-				return error.trim();
-			}
-
-			if ( error && typeof error === 'object' && ! Array.isArray( error ) ) {
-				const message = ( error as Record<string, unknown> ).message;
-				if ( typeof message === 'string' && message.trim() ) {
-					return message.trim();
-				}
-			}
-
-			const message = record.message;
-			if ( typeof message === 'string' && message.trim() ) {
-				return message.trim();
-			}
-		}
-	} catch {
-		// Tool results are often plain text. Use the raw content below.
-	}
-
-	return content;
-}
-
-function renderGenerationCard( group: ToolGroup ): ReactNode {
-	const hasError = group.success === false;
-	const errorMessage = hasError ? generationErrorMessage( group ) : '';
-
-	return createElement(
-		'div',
-		{ className: `frontend-agent-chat__tool-card frontend-agent-chat__tool-card--generation${ hasError ? ' has-error' : '' }` },
-		createElement( 'div', { className: 'frontend-agent-chat__tool-card-title' }, __( 'WordPress Site Generator', 'frontend-agent-chat' ) ),
-		createElement(
-			'p',
-			{ className: 'frontend-agent-chat__tool-card-copy' },
-			hasError
-				? __( 'The WordPress site generator could not be started.', 'frontend-agent-chat' )
-				: __( 'Studio Web is preparing your WordPress site from the captured site brief.', 'frontend-agent-chat' )
-		),
-		hasError && createElement( 'p', { className: 'frontend-agent-chat__tool-card-error' }, errorMessage )
-	);
-}
-
 function artifactStatusLabel( status: ArtifactPhaseStatus ): string {
 	switch ( status ) {
 		case 'pending':
 			return __( 'Pending', 'frontend-agent-chat' );
 		case 'running':
 			return __( 'Running', 'frontend-agent-chat' );
+		case 'ready':
+			return __( 'Ready', 'frontend-agent-chat' );
 		case 'completed':
 			return __( 'Completed', 'frontend-agent-chat' );
 		case 'failed':
@@ -792,6 +741,8 @@ function artifactStatusCopy( payload: ArtifactStatusPayload ): string {
 			return __( 'Waiting to start this artifact phase.', 'frontend-agent-chat' );
 		case 'running':
 			return __( 'This artifact phase is in progress.', 'frontend-agent-chat' );
+		case 'ready':
+			return __( 'This artifact phase is ready.', 'frontend-agent-chat' );
 		case 'completed':
 			return __( 'This artifact phase completed successfully.', 'frontend-agent-chat' );
 		case 'failed':
@@ -1086,14 +1037,14 @@ export default function AgentChat( {
 	const toolRenderers = useMemo(
 		() => ( {
 			artifact_phase: renderArtifactStatusCard,
+			start_artifact_generation: renderArtifactStatusCard,
 			artifact_status: renderArtifactStatusCard,
 			artifact_status_update: renderArtifactStatusCard,
 			artifact_task_status: renderArtifactStatusCard,
 			edit_post_blocks: renderDiffCard,
 			replace_post_blocks: renderDiffCard,
 			insert_content: renderDiffCard,
-			studio_web_propose_questions: renderQuestionCard,
-			studio_web_start_generation: renderGenerationCard,
+			present_question: renderQuestionCard,
 		} ),
 		[]
 	);


### PR DESCRIPTION
## Summary
- Remove Studio Web-specific tool renderers and copy from the generic frontend chat package.
- Add generic `present_question` and `start_artifact_generation` renderer keys.
- Teach generic artifact status cards to display `ready` states.

## Testing
- `npm run typecheck`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refactored the renderer mapping and verified the package build/typecheck for Chris to review.