### PR TITLE
Mark Automattic as the frontend chat home

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A small React app mounts a floating action button (FAB) in the bottom-right corn
 
 The widget is a frontend shell. Agent runtime, tools, prompt policy, pending-action resolution, access control, and conversation sessions are provided by Agents API abilities and host-registered stores.
 
+`@extrachill/chat` remains the current React UI dependency because it speaks the REST contract used by this plugin's Agents API adapter. Other Automattic chat UI packages can converge here once they support the Agents API session, run-control, pending-action, and message contracts directly.
+
 ## Configuration
 
 Each site configures the chat widget via the `frontend_agent_chat_config` option.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Floating agent chat widget for WordPress. Connects to canonical abilities from [Agents API](https://github.com/Automattic/agents-api) and stays independent from any concrete runtime or storage plugin.
 
+This plugin is the frontend companion for Agents API-powered WordPress agents. It was originally incubated as Data Machine Frontend Chat, then renamed and decoupled as the Agents API contract became the shared runtime boundary.
+
 ## How it works
 
 A small React app mounts a floating action button (FAB) in the bottom-right corner of every page. Click it and a slide-in drawer opens with a full chat interface powered by the [`@extrachill/chat`](https://www.npmjs.com/package/@extrachill/chat) package.

--- a/frontend-agent-chat.php
+++ b/frontend-agent-chat.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Frontend Agent Chat
- * Plugin URI: https://github.com/Extra-Chill/frontend-agent-chat
+ * Plugin URI: https://github.com/Automattic/frontend-agent-chat
  * Description: Floating agent chat widget for WordPress agents powered by Agents API abilities.
  * Version: 0.10.0
  * Author: Chris Huber


### PR DESCRIPTION
## Summary
- Update the plugin URI to the transferred Automattic repository.
- Document Frontend Agent Chat as the frontend companion for Agents API-powered WordPress agents while preserving its Data Machine incubation history.
- Keep `@extrachill/chat` as the current React UI implementation dependency.

## Testing
- `npm run typecheck`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small README/plugin header update, ran checks, and prepared the PR.