### PR TITLE
chore: update Plugin URI to Automattic/frontend-agent-chat

### DIFF
--- a/frontend-agent-chat.php
+++ b/frontend-agent-chat.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Frontend Agent Chat
- * Plugin URI: https://github.com/Extra-Chill/frontend-agent-chat
+ * Plugin URI: https://github.com/Automattic/frontend-agent-chat
  * Description: Floating agent chat widget for WordPress agents powered by Agents API abilities.
  * Version: 0.10.0
  * Author: Chris Huber


### PR DESCRIPTION
## Summary
- The repo was transferred from `Extra-Chill` to `Automattic` to support agents-api adoption and serve as a reference example.
- Updates the `Plugin URI` header to the canonical Automattic location.

## Notes
- The `@extrachill/chat` dependency is a separate repo and is intentionally unchanged.