### PR TITLE
Render citation source cards in chat messages

### DIFF
--- a/inc/rest.php
+++ b/inc/rest.php
@@ -1038,8 +1038,9 @@ function frontend_agent_chat_normalize_source_card( $raw_source ): array {
 		'title'       => array( 'title', 'source_title', 'sourceTitle', 'name', 'label' ),
 		'url'         => array( 'url', 'source_url', 'sourceUrl', 'href', 'link' ),
 		'snippet'     => array( 'snippet', 'excerpt', 'summary', 'text', 'content', 'quote' ),
-		'document_id' => array( 'document_id', 'documentId', 'doc_id', 'docId', 'document', 'id' ),
-		'chunk_id'    => array( 'chunk_id', 'chunkId', 'chunk', 'chunk_ref', 'chunkRef' ),
+		'source_id'   => array( 'source_id', 'sourceId' ),
+		'item_id'     => array( 'item_id', 'itemId', 'document_id', 'documentId', 'doc_id', 'docId', 'document', 'id' ),
+		'fragment_id' => array( 'fragment_id', 'fragmentId', 'chunk_id', 'chunkId', 'chunk', 'chunk_ref', 'chunkRef' ),
 	) as $target_key => $source_keys ) {
 		$value = frontend_agent_chat_first_string_value( $raw_source, $source_keys );
 		if ( '' !== $value ) {

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -872,10 +872,15 @@ function frontend_agent_chat_normalize_result_messages( array $result, string $u
 			'role'    => 'user',
 			'content' => $user_message,
 		);
-		$messages[] = array(
+		$assistant = array(
 			'role'    => 'assistant',
 			'content' => (string) ( $result['reply'] ?? '' ),
 		);
+		if ( is_array( $result['metadata'] ?? null ) ) {
+			$assistant['metadata'] = $result['metadata'];
+		}
+		$messages[] = $assistant;
+		$messages   = frontend_agent_chat_append_source_card_tool_messages( $messages, $assistant['metadata'] ?? array() );
 	}
 
 	return $messages;
@@ -926,9 +931,156 @@ function frontend_agent_chat_session_messages( array $source ): array {
 		}
 
 		$messages[] = $normalized;
+		if ( 'assistant' === $role ) {
+			$messages = frontend_agent_chat_append_source_card_tool_messages( $messages, $normalized['metadata'] ?? array() );
+		}
 	}
 
 	return $messages;
+}
+
+/**
+ * Append source-card tool envelopes for assistant message citation metadata.
+ *
+ * @param array $messages Normalized conversation messages.
+ * @param array $metadata Message metadata.
+ * @return array
+ */
+function frontend_agent_chat_append_source_card_tool_messages( array $messages, array $metadata ): array {
+	$sources = frontend_agent_chat_normalize_source_cards( $metadata );
+	if ( empty( $sources ) ) {
+		return $messages;
+	}
+
+	$tool_call_id = 'source_cards_' . count( $messages );
+	$messages[]   = array(
+		'role'     => 'assistant',
+		'content'  => '',
+		'metadata' => array(
+			'type'         => 'tool_call',
+			'tool_name'    => 'source_cards',
+			'tool_call_id' => $tool_call_id,
+			'parameters'   => array( 'sources' => $sources ),
+		),
+	);
+	$messages[]   = array(
+		'role'     => 'user',
+		'content'  => frontend_agent_chat_json_encode( array( 'sources' => $sources ) ),
+		'metadata' => array(
+			'type'         => 'tool_result',
+			'tool_name'    => 'source_cards',
+			'tool_call_id' => $tool_call_id,
+			'success'      => true,
+		),
+	);
+
+	return $messages;
+}
+
+/**
+ * Normalize generic citation/source metadata into source-card payloads.
+ *
+ * @param array $metadata Message or response metadata.
+ * @return array<int,array<string,string>>
+ */
+function frontend_agent_chat_normalize_source_cards( array $metadata ): array {
+	$raw_sources = frontend_agent_chat_find_source_card_values( $metadata );
+	$sources     = array();
+	foreach ( $raw_sources as $raw_source ) {
+		$source = frontend_agent_chat_normalize_source_card( $raw_source );
+		if ( ! empty( $source ) ) {
+			$sources[] = $source;
+		}
+	}
+
+	return $sources;
+}
+
+/**
+ * Find source-card arrays in a metadata payload.
+ *
+ * @param array $metadata Metadata payload.
+ * @return array<int,mixed>
+ */
+function frontend_agent_chat_find_source_card_values( array $metadata ): array {
+	foreach ( array( 'sources', 'citations', 'source_cards', 'sourceCards' ) as $key ) {
+		if ( isset( $metadata[ $key ] ) && is_array( $metadata[ $key ] ) ) {
+			return array_values( $metadata[ $key ] );
+		}
+	}
+
+	foreach ( array( 'source', 'citation' ) as $key ) {
+		if ( isset( $metadata[ $key ] ) ) {
+			return array( $metadata[ $key ] );
+		}
+	}
+
+	return array();
+}
+
+/**
+ * Normalize one source-card payload.
+ *
+ * @param mixed $raw_source Raw source payload.
+ * @return array<string,string>
+ */
+function frontend_agent_chat_normalize_source_card( $raw_source ): array {
+	if ( is_string( $raw_source ) ) {
+		$raw_source = array( 'url' => $raw_source );
+	}
+
+	if ( ! is_array( $raw_source ) ) {
+		return array();
+	}
+
+	$source = array();
+	foreach ( array(
+		'title'       => array( 'title', 'source_title', 'sourceTitle', 'name', 'label' ),
+		'url'         => array( 'url', 'source_url', 'sourceUrl', 'href', 'link' ),
+		'snippet'     => array( 'snippet', 'excerpt', 'summary', 'text', 'content', 'quote' ),
+		'document_id' => array( 'document_id', 'documentId', 'doc_id', 'docId', 'document', 'id' ),
+		'chunk_id'    => array( 'chunk_id', 'chunkId', 'chunk', 'chunk_ref', 'chunkRef' ),
+	) as $target_key => $source_keys ) {
+		$value = frontend_agent_chat_first_string_value( $raw_source, $source_keys );
+		if ( '' !== $value ) {
+			$source[ $target_key ] = $value;
+		}
+	}
+
+	return ( ! empty( $source['title'] ) || ! empty( $source['url'] ) || ! empty( $source['snippet'] ) ) ? $source : array();
+}
+
+/**
+ * Read the first non-empty scalar value from an array.
+ *
+ * @param array $source Source array.
+ * @param array $keys Candidate keys.
+ * @return string
+ */
+function frontend_agent_chat_first_string_value( array $source, array $keys ): string {
+	foreach ( $keys as $key ) {
+		if ( ! isset( $source[ $key ] ) || is_array( $source[ $key ] ) || is_object( $source[ $key ] ) ) {
+			continue;
+		}
+
+		$value = trim( (string) $source[ $key ] );
+		if ( '' !== $value ) {
+			return $value;
+		}
+	}
+
+	return '';
+}
+
+/**
+ * Encode JSON with WordPress escaping when available.
+ *
+ * @param mixed $value Value to encode.
+ * @return string
+ */
+function frontend_agent_chat_json_encode( $value ): string {
+	$json = function_exists( 'wp_json_encode' ) ? wp_json_encode( $value ) : json_encode( $value );
+	return is_string( $json ) ? $json : '';
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat#v0.13.0"
+				"@extrachill/chat": "^0.14.0"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2656,8 +2656,9 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.13.0",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#51389ced7d6996740d5c3e512641390806707a33",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.14.0.tgz",
+			"integrity": "sha512-reP65ZD0vR3RwJmqQqu9NzG235033tgkEKpFCw8ZdpqEI8Z/8iVE2NV1xfm4YMmDjo25WH0fA9y3r9cSPsUDyQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat#v0.13.0"
+				"@extrachill/chat": "github:Extra-Chill/chat#v0.14.0"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2656,8 +2656,8 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.13.0",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#51389ced7d6996740d5c3e512641390806707a33",
+			"version": "0.14.0",
+			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#11825557d9368aa2c25bdc77c57848f4af8cdcf6",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat#v0.13.0"
+		"@extrachill/chat": "^0.14.0"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat#v0.13.0"
+		"@extrachill/chat": "github:Extra-Chill/chat#v0.14.0"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -165,8 +165,9 @@ interface SourceCardPayload {
 	title?: string;
 	url?: string;
 	snippet?: string;
-	documentId?: string;
-	chunkId?: string;
+	sourceId?: string;
+	itemId?: string;
+	fragmentId?: string;
 	accessibleLabel?: string;
 }
 
@@ -485,8 +486,9 @@ function normalizeSourceCard( value: unknown ): SourceCardPayload | null {
 		title: readString( source, [ 'title', 'source_title', 'sourceTitle', 'name', 'label' ] ),
 		url: readString( source, [ 'url', 'source_url', 'sourceUrl', 'href', 'link' ] ),
 		snippet: readString( source, [ 'snippet', 'excerpt', 'summary', 'text', 'content', 'quote' ] ),
-		documentId: readString( source, [ 'document_id', 'documentId', 'doc_id', 'docId', 'document', 'id' ] ),
-		chunkId: readString( source, [ 'chunk_id', 'chunkId', 'chunk', 'chunk_ref', 'chunkRef' ] ),
+		sourceId: readString( source, [ 'source_id', 'sourceId' ] ),
+		itemId: readString( source, [ 'item_id', 'itemId', 'document_id', 'documentId', 'doc_id', 'docId', 'document', 'id' ] ),
+		fragmentId: readString( source, [ 'fragment_id', 'fragmentId', 'chunk_id', 'chunkId', 'chunk', 'chunk_ref', 'chunkRef' ] ),
 		accessibleLabel: readString( source, [ 'accessible_label', 'accessibleLabel', 'aria_label', 'ariaLabel' ] ),
 	};
 
@@ -528,7 +530,7 @@ function sourceCardsFromToolGroup( group: ToolGroup ): SourceCardPayload[] {
 
 	const seen = new Set< string >();
 	return sources.filter( ( source ) => {
-		const key = [ source.url, source.title, source.documentId, source.chunkId, source.snippet ].join( '\u0000' );
+		const key = [ source.url, source.title, source.sourceId, source.itemId, source.fragmentId, source.snippet ].join( '\u0000' );
 		if ( seen.has( key ) ) {
 			return false;
 		}
@@ -839,16 +841,20 @@ function renderSourceCards( group: ToolGroup ): ReactNode {
 					) : createElement( 'span', { className: 'frontend-agent-chat__source-card-title' }, title )
 				),
 				source.snippet && createElement( 'p', { className: 'frontend-agent-chat__source-card-snippet' }, source.snippet ),
-				( source.documentId || source.chunkId ) && createElement(
+				( source.sourceId || source.itemId || source.fragmentId ) && createElement(
 					'dl',
 					{ className: 'frontend-agent-chat__source-card-debug' },
-					source.documentId && createElement( 'div', null,
-						createElement( 'dt', null, __( 'Document', 'frontend-agent-chat' ) ),
-						createElement( 'dd', null, source.documentId )
+					source.sourceId && createElement( 'div', null,
+						createElement( 'dt', null, __( 'Source ID', 'frontend-agent-chat' ) ),
+						createElement( 'dd', null, source.sourceId )
 					),
-					source.chunkId && createElement( 'div', null,
-						createElement( 'dt', null, __( 'Chunk', 'frontend-agent-chat' ) ),
-						createElement( 'dd', null, source.chunkId )
+					source.itemId && createElement( 'div', null,
+						createElement( 'dt', null, __( 'Item ID', 'frontend-agent-chat' ) ),
+						createElement( 'dd', null, source.itemId )
+					),
+					source.fragmentId && createElement( 'div', null,
+						createElement( 'dt', null, __( 'Fragment ID', 'frontend-agent-chat' ) ),
+						createElement( 'dd', null, source.fragmentId )
 					)
 				)
 			);

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -19,13 +19,13 @@
  */
 import {
 	Chat,
-	DiffCard,
-	QuestionCard,
 	ToolMessage,
-	useClientContextMetadata,
-	parseCanonicalDiffFromToolGroup,
+	createArtifactStatusToolRenderer,
+	createPendingActionDiffRenderer,
+	createQuestionToolRenderer,
+	normalizeRunEvent,
 } from '@extrachill/chat';
-import type { ChatMessage, ChatMessageSuggestion, ToolGroup, DiffData, FetchFn, MediaUploadFn, ToolRendererContext, QuestionChoice, ChatRunCapabilities, CancelRunInput, QueueMessageInput, QueueMessageResult } from '@extrachill/chat';
+import type { ArtifactStatus, ArtifactStatusPayload, ChatMessage, ChatMessageSuggestion, ChatRunAdapter, ChatRunCapabilities, ChatRunEvent, FetchFn, MediaUploadFn, QueueMessageResult } from '@extrachill/chat';
 import type { ChangeEvent, ReactNode } from 'react';
 
 /**
@@ -95,21 +95,13 @@ interface RunControlResponse {
 	};
 }
 
-interface ChatRunEvent {
-	id: string;
-	type: string;
-	message?: string;
-	created_at?: string;
-	metadata?: Record< string, unknown >;
-}
-
 interface RunEventsResponse {
 	success?: boolean;
 	data?: {
 		run_id?: string;
 		session_id?: string;
 		status?: string;
-		events?: ChatRunEvent[];
+		events?: Record< string, unknown >[];
 		cursor?: string;
 		has_more?: boolean;
 	};
@@ -142,40 +134,8 @@ interface AgentsResponse {
 	};
 }
 
-type ArtifactPhaseStatus = 'pending' | 'running' | 'ready' | 'completed' | 'failed' | 'retrying';
-
-interface ArtifactThumbnail {
-	url: string;
-	alt?: string;
-}
-
-interface ArtifactStatusPayload {
-	title: string;
-	phase: string;
-	status: ArtifactPhaseStatus;
-	description?: string;
-	diagnosticsCount?: number;
-	previewUrl?: string;
-	materializedUrl?: string;
-	thumbnails: ArtifactThumbnail[];
-	error?: string;
-}
-
 const DEFAULT_EXPAND_ICON_PATH = 'M3 8V3h5M21 8V3h-5M3 16v5h5M21 16v5h-5';
 const DEFAULT_COLLAPSE_ICON_PATH = 'M8 3v5H3M16 3v5h5M8 21v-5H3M16 21v-5h5';
-
-/**
- * Parse a tool result into DiffData for DiffCard rendering.
- *
- * Returns null if the tool result is not a preview action (e.g. the
- * tool was called without preview=true, or the result is malformed).
- *
- * @param group Tool group.
- * @return Diff data when present.
- */
-function parseDiffFromToolResult( group: ToolGroup ): DiffData | null {
-	return parseCanonicalDiffFromToolGroup( group );
-}
 
 /**
  * Resolve a pending action by id.
@@ -228,6 +188,9 @@ function createAgentFetch( agentSlug: string ): FetchFn {
 	return ( options ) => {
 		const method = options.method ?? 'GET';
 		const separator = options.path.includes( '?' ) ? '&' : '?';
+		const data = options.data && typeof options.data === 'object' && ! Array.isArray( options.data )
+			? options.data as Record< string, unknown >
+			: {};
 
 		return apiFetch( {
 			path: method === 'GET' || method === 'DELETE'
@@ -235,7 +198,7 @@ function createAgentFetch( agentSlug: string ): FetchFn {
 				: options.path,
 			method: options.method,
 			data: method === 'POST'
-				? { ...getPageContext(), ...( options.data ?? {} ), agent: agentSlug }
+				? { ...getPageContext(), ...data, agent: agentSlug }
 				: options.data,
 			headers: options.headers,
 		} );
@@ -246,22 +209,14 @@ function createRunCapabilities( capabilities?: AgentChatProps['capabilities'] ):
 	return {
 		cancel: !! capabilities?.chat_run_cancel,
 		queue: !! capabilities?.chat_message_queue,
+		status: !! capabilities?.chat_run_status,
+		events: !! capabilities?.chat_run_events,
 	};
 }
 
 function getRunId( metadata: Record< string, unknown > ): string | null {
 	const runId = metadata.run_id ?? metadata.runId;
 	return typeof runId === 'string' && runId.trim() ? runId : null;
-}
-
-function createCancelRun( fetchFn: FetchFn, basePath: string ): ( input: CancelRunInput ) => Promise< void > {
-	return async ( input ) => {
-		await fetchFn( {
-			path: `${ basePath }/runs/${ encodeURIComponent( input.runId ) }/cancel`,
-			method: 'POST',
-			data: { session_id: input.sessionId },
-		} );
-	};
 }
 
 function normalizeQueueResult( response: RunControlResponse ): QueueMessageResult {
@@ -278,32 +233,74 @@ function normalizeQueueResult( response: RunControlResponse ): QueueMessageResul
 	};
 }
 
-function createQueueMessage( fetchFn: FetchFn, uploadFn: MediaUploadFn, basePath: string ): ( input: QueueMessageInput ) => Promise< QueueMessageResult > {
-	return async ( input ) => {
-		const attachments = input.files?.length
-			? await Promise.all( input.files.map( async ( file ) => {
-				const uploaded = await uploadFn( file );
-				return {
-					filename: file.name,
-					mime_type: file.type,
-					url: uploaded.url,
-					media_id: uploaded.media_id,
-				};
-			} ) )
-			: [];
+function createFrontendRunAdapter(
+	fetchFn: FetchFn,
+	uploadFn: MediaUploadFn,
+	basePath: string,
+	capabilities?: AgentChatProps['capabilities']
+): ChatRunAdapter {
+	return {
+		capabilities: createRunCapabilities( capabilities ),
+		getRunId,
+		async cancel( input ) {
+			await fetchFn( {
+				path: `${ basePath }/runs/${ encodeURIComponent( input.runId ) }/cancel`,
+				method: 'POST',
+				data: { session_id: input.sessionId },
+			} );
+		},
+		async queue( input ) {
+			const attachments = input.files?.length
+				? await Promise.all( input.files.map( async ( file ) => {
+					const uploaded = await uploadFn( file );
+					return {
+						filename: file.name,
+						mime_type: file.type,
+						url: uploaded.url,
+						media_id: uploaded.media_id,
+					};
+				} ) )
+				: [];
 
-		const response = await fetchFn( {
-			path: `${ basePath }/queue`,
-			method: 'POST',
-			data: {
-				session_id: input.sessionId,
-				run_id: input.runId,
-				message: input.content,
-				attachments,
-			},
-		} ) as RunControlResponse;
+			const response = await fetchFn( {
+				path: `${ basePath }/queue`,
+				method: 'POST',
+				data: {
+					session_id: input.sessionId,
+					run_id: input.runId,
+					message: input.content,
+					attachments,
+				},
+			} ) as RunControlResponse;
 
-		return normalizeQueueResult( response );
+			return normalizeQueueResult( response );
+		},
+		async listEvents( input ) {
+			let cursor = '0';
+			let hasMore = true;
+			const events: ChatRunEvent[] = [];
+			while ( hasMore ) {
+				const response = await fetchFn( {
+					path: `${ basePath }/runs/${ encodeURIComponent( input.runId ) }/events?session_id=${ encodeURIComponent( input.sessionId ) }&cursor=${ encodeURIComponent( cursor ) }`,
+				} ) as RunEventsResponse;
+				const data = response.data ?? {};
+				for ( const event of data.events ?? [] ) {
+					const normalized = normalizeRunEvent(
+						{ ...event, run_id: input.runId, session_id: input.sessionId, status: data.status },
+						input.runId
+					);
+					if ( normalized ) {
+						events.push( normalized );
+					}
+				}
+
+				const nextCursor = data.cursor ?? cursor;
+				hasMore = !! data.has_more && nextCursor !== cursor;
+				cursor = nextCursor;
+			}
+
+			return events;
+		},
 	};
 }
 
@@ -352,32 +349,20 @@ function dispatchRunEvent( event: ChatRunEvent, detail: Record< string, unknown 
 	} );
 }
 
-async function dispatchRunEvents( fetchFn: FetchFn, basePath: string, metadata: Record< string, unknown > ): Promise< void > {
+async function dispatchRunEvents( runAdapter: ChatRunAdapter, metadata: Record< string, unknown > ): Promise< void > {
 	const runId = metadata.run_id ?? metadata.runId;
 	const sessionId = metadata.session_id ?? metadata.sessionId;
-	if ( typeof runId !== 'string' || ! runId || typeof sessionId !== 'string' || ! sessionId ) {
+	if ( ! runAdapter.listEvents || typeof runId !== 'string' || ! runId || typeof sessionId !== 'string' || ! sessionId ) {
 		return;
 	}
 
-	let cursor = '0';
-	let hasMore = true;
-	while ( hasMore ) {
-		const separator = `${ basePath }/runs/${ encodeURIComponent( runId ) }/events`.includes( '?' ) ? '&' : '?';
-		const response = await fetchFn( {
-			path: `${ basePath }/runs/${ encodeURIComponent( runId ) }/events${ separator }session_id=${ encodeURIComponent( sessionId ) }&cursor=${ encodeURIComponent( cursor ) }`,
-		} ) as RunEventsResponse;
-		const data = response.data ?? {};
-		for ( const event of data.events ?? [] ) {
-			dispatchRunEvent( event, {
-				run_id: runId,
-				session_id: sessionId,
-				status: data.status,
-			} );
-		}
-
-		const nextCursor = data.cursor ?? cursor;
-		hasMore = !! data.has_more && nextCursor !== cursor;
-		cursor = nextCursor;
+	const events = await runAdapter.listEvents( { runId, sessionId } );
+	for ( const event of events ) {
+		dispatchRunEvent( event, {
+			run_id: runId,
+			session_id: sessionId,
+			status: event.status,
+		} );
 	}
 }
 
@@ -406,315 +391,7 @@ const wpMediaUpload: MediaUploadFn = async ( file: File ) => {
 	};
 };
 
-function renderDiffCard( group: ToolGroup ): ReactNode {
-	const diff = parseDiffFromToolResult( group );
-	if ( ! diff ) {
-		return null;
-	}
-
-	return createElement( DiffCard, {
-		diff,
-		onAccept: ( actionId: string ) => resolvePendingAction( actionId, 'accepted' ),
-		onReject: ( actionId: string ) => resolvePendingAction( actionId, 'rejected' ),
-	} );
-}
-
-interface QuestionPayload {
-	question?: string;
-	choices?: QuestionChoice[];
-	allow_freeform?: boolean;
-	freeform_label?: string;
-	freeform_placeholder?: string;
-}
-
-function parseJsonObject( value: string ): Record< string, unknown > | null {
-	try {
-		const parsed = JSON.parse( value );
-		return parsed && typeof parsed === 'object' && ! Array.isArray( parsed )
-			? parsed as Record< string, unknown >
-			: null;
-	} catch {
-		return null;
-	}
-}
-
-function asRecord( value: unknown ): Record< string, unknown > | null {
-	return value && typeof value === 'object' && ! Array.isArray( value )
-		? value as Record< string, unknown >
-		: null;
-}
-
-function readString( source: Record< string, unknown >, keys: string[] ): string | undefined {
-	for ( const key of keys ) {
-		const value = source[ key ];
-		if ( typeof value === 'string' && value.trim() ) {
-			return value.trim();
-		}
-	}
-
-	return undefined;
-}
-
-function readNumber( source: Record< string, unknown >, keys: string[] ): number | undefined {
-	for ( const key of keys ) {
-		const value = source[ key ];
-		if ( typeof value === 'number' && Number.isFinite( value ) ) {
-			return value;
-		}
-	}
-
-	return undefined;
-}
-
-function titleFromPhase( phase: string ): string {
-	return phase
-		.replace( /[-_]+/g, ' ' )
-		.replace( /\b\w/g, ( match ) => match.toUpperCase() );
-}
-
-function normalizeArtifactStatus( status: unknown ): ArtifactPhaseStatus | null {
-	if ( typeof status !== 'string' ) {
-		return null;
-	}
-
-	const normalized = status.trim().toLowerCase();
-	if ( [ 'pending', 'running', 'ready', 'completed', 'failed', 'retrying' ].includes( normalized ) ) {
-		return normalized as ArtifactPhaseStatus;
-	}
-
-	return null;
-}
-
-function firstNestedRecord( source: Record< string, unknown >, keys: string[] ): Record< string, unknown > | null {
-	for ( const key of keys ) {
-		const record = asRecord( source[ key ] );
-		if ( record ) {
-			return record;
-		}
-	}
-
-	return null;
-}
-
-function unwrapArtifactSource( source: Record< string, unknown > ): Record< string, unknown > {
-	return firstNestedRecord( source, [ 'artifact_phase', 'artifactPhase', 'phase_metadata', 'phaseMetadata', 'artifact_status', 'artifactStatus' ] ) ?? source;
-}
-
-function collectArtifactSources( group: ToolGroup ): Record< string, unknown >[] {
-	const sources: Record< string, unknown >[] = [ group.parameters ];
-	const result = group.resultMessage ? parseJsonObject( group.resultMessage.content ) : null;
-	if ( result ) {
-		sources.push( result );
-		const nestedResult = asRecord( result.result );
-		if ( nestedResult ) {
-			sources.push( nestedResult );
-		}
-		const nestedData = asRecord( result.data );
-		if ( nestedData ) {
-			sources.push( nestedData );
-		}
-	}
-
-	return sources.map( unwrapArtifactSource );
-}
-
-function getArtifactSourceValue( sources: Record< string, unknown >[], keys: string[] ): unknown {
-	for ( const source of sources ) {
-		for ( const key of keys ) {
-			if ( source[ key ] !== undefined && source[ key ] !== null ) {
-				return source[ key ];
-			}
-		}
-	}
-
-	return undefined;
-}
-
-function readArtifactString( sources: Record< string, unknown >[], keys: string[] ): string | undefined {
-	for ( const source of sources ) {
-		const value = readString( source, keys );
-		if ( value ) {
-			return value;
-		}
-	}
-
-	return undefined;
-}
-
-function readArtifactNumber( sources: Record< string, unknown >[], keys: string[] ): number | undefined {
-	for ( const source of sources ) {
-		const value = readNumber( source, keys );
-		if ( value !== undefined ) {
-			return value;
-		}
-	}
-
-	return undefined;
-}
-
-function normalizeThumbnail( value: unknown ): ArtifactThumbnail | null {
-	if ( typeof value === 'string' && value.trim() ) {
-		return { url: value.trim() };
-	}
-
-	const record = asRecord( value );
-	if ( ! record ) {
-		return null;
-	}
-
-	const url = readString( record, [ 'thumbnail_url', 'thumbnailUrl', 'thumb_url', 'thumbUrl', 'url', 'src' ] );
-	if ( ! url ) {
-		return null;
-	}
-
-	return {
-		url,
-		alt: readString( record, [ 'alt', 'alt_text', 'altText', 'label', 'title' ] ),
-	};
-}
-
-function collectArtifactThumbnails( sources: Record< string, unknown >[] ): ArtifactThumbnail[] {
-	const thumbnails: ArtifactThumbnail[] = [];
-	const thumbnailValue = getArtifactSourceValue( sources, [ 'thumbnails', 'thumbnail_urls', 'thumbnailUrls', 'assets', 'imported_assets', 'importedAssets' ] );
-	let rawThumbnails: unknown[] = [];
-	if ( Array.isArray( thumbnailValue ) ) {
-		rawThumbnails = thumbnailValue;
-	} else if ( thumbnailValue ) {
-		rawThumbnails = [ thumbnailValue ];
-	}
-
-	for ( const value of rawThumbnails ) {
-		const thumbnail = normalizeThumbnail( value );
-		if ( thumbnail ) {
-			thumbnails.push( thumbnail );
-		}
-	}
-
-	return thumbnails.slice( 0, 4 );
-}
-
-function artifactDiagnosticsCount( sources: Record< string, unknown >[] ): number | undefined {
-	const explicitCount = readArtifactNumber( sources, [ 'diagnostics_count', 'diagnosticsCount', 'diagnostic_count', 'diagnosticCount' ] );
-	if ( explicitCount !== undefined ) {
-		return explicitCount;
-	}
-
-	const diagnostics = getArtifactSourceValue( sources, [ 'diagnostics', 'issues', 'warnings' ] );
-	if ( Array.isArray( diagnostics ) ) {
-		return diagnostics.length;
-	}
-
-	const diagnosticsRecord = asRecord( diagnostics );
-	return diagnosticsRecord ? Object.keys( diagnosticsRecord ).length : undefined;
-}
-
-function artifactErrorMessage( sources: Record< string, unknown >[] ): string | undefined {
-	const explicitError = readArtifactString( sources, [ 'error', 'error_message', 'errorMessage', 'failure_reason', 'failureReason' ] );
-	if ( explicitError ) {
-		return explicitError;
-	}
-
-	for ( const source of sources ) {
-		const error = asRecord( source.error );
-		const message = error ? readString( error, [ 'message', 'detail' ] ) : undefined;
-		if ( message ) {
-			return message;
-		}
-	}
-
-	return undefined;
-}
-
-function artifactPayloadFromToolGroup( group: ToolGroup ): ArtifactStatusPayload | null {
-	const sources = collectArtifactSources( group );
-	const phase = readArtifactString( sources, [ 'phase', 'artifact_phase', 'artifactPhase', 'step', 'stage' ] );
-	let statusFromSuccess: ArtifactStatusPayload[ 'status' ] | null = null;
-	if ( group.success === false ) {
-		statusFromSuccess = 'failed';
-	} else if ( group.success === true ) {
-		statusFromSuccess = 'completed';
-	}
-	const status = normalizeArtifactStatus( getArtifactSourceValue( sources, [ 'status', 'state', 'phase_status', 'phaseStatus' ] ) )
-		?? statusFromSuccess;
-
-	if ( ! phase || ! status ) {
-		return null;
-	}
-
-	const title = readArtifactString( sources, [ 'title', 'label', 'name' ] ) ?? titleFromPhase( phase );
-
-	return {
-		title,
-		phase,
-		status,
-		description: readArtifactString( sources, [ 'description', 'message', 'summary', 'detail' ] ),
-		diagnosticsCount: artifactDiagnosticsCount( sources ),
-		previewUrl: readArtifactString( sources, [ 'preview_url', 'previewUrl', 'url' ] ),
-		materializedUrl: readArtifactString( sources, [ 'materialized_url', 'materializedUrl', 'final_url', 'finalUrl', 'result_url', 'resultUrl' ] ),
-		thumbnails: collectArtifactThumbnails( sources ),
-		error: artifactErrorMessage( sources ),
-	};
-}
-
-function normalizeQuestionChoice( value: unknown ): QuestionChoice | null {
-	if ( ! value || typeof value !== 'object' || Array.isArray( value ) ) {
-		return null;
-	}
-
-	const choice = value as Record< string, unknown >;
-	const label = typeof choice.label === 'string' ? choice.label.trim() : '';
-	if ( ! label ) {
-		return null;
-	}
-
-	return {
-		label,
-		message: typeof choice.message === 'string' ? choice.message : undefined,
-		description: typeof choice.description === 'string' ? choice.description : undefined,
-	};
-}
-
-function questionPayloadFromToolGroup( group: ToolGroup ): QuestionPayload | null {
-	const result = group.resultMessage ? parseJsonObject( group.resultMessage.content ) : null;
-	const source = result && typeof result.result === 'object' && ! Array.isArray( result.result )
-		? result.result as Record< string, unknown >
-		: result ?? group.parameters;
-	const question = typeof source.question === 'string' ? source.question.trim() : '';
-	if ( ! question ) {
-		return null;
-	}
-
-	const choices = Array.isArray( source.choices )
-		? source.choices.map( normalizeQuestionChoice ).filter( ( choice ): choice is QuestionChoice => !! choice )
-		: [];
-
-	return {
-		question,
-		choices,
-		allow_freeform: source.allow_freeform !== false,
-		freeform_label: typeof source.freeform_label === 'string' ? source.freeform_label : undefined,
-		freeform_placeholder: typeof source.freeform_placeholder === 'string' ? source.freeform_placeholder : undefined,
-	};
-}
-
-function renderQuestionCard( group: ToolGroup, context: ToolRendererContext ): ReactNode {
-	const payload = questionPayloadFromToolGroup( group );
-	if ( ! payload ) {
-		return null;
-	}
-
-	return createElement( QuestionCard, {
-		question: payload.question ?? '',
-		choices: payload.choices,
-		allowFreeform: false,
-		freeformLabel: payload.freeform_label,
-		freeformPlaceholder: payload.freeform_placeholder,
-		disabled: context.isLoading,
-		onSubmitAnswer: context.sendMessage,
-	} );
-}
-
-function artifactStatusLabel( status: ArtifactPhaseStatus ): string {
+function artifactStatusLabel( status: ArtifactStatus ): string {
 	switch ( status ) {
 		case 'pending':
 			return __( 'Pending', 'frontend-agent-chat' );
@@ -752,15 +429,10 @@ function artifactStatusCopy( payload: ArtifactStatusPayload ): string {
 	}
 }
 
-function renderArtifactStatusCard( group: ToolGroup ): ReactNode {
-	const payload = artifactPayloadFromToolGroup( group );
-	if ( ! payload ) {
-		return createElement( ToolMessage, { group } );
-	}
-
+function renderArtifactStatusPayload( payload: ArtifactStatusPayload ): ReactNode {
 	const hasError = payload.status === 'failed';
-	const linkUrl = payload.materializedUrl ?? payload.previewUrl;
-	const linkLabel = payload.materializedUrl
+	const linkUrl = payload.resultUrl ?? payload.previewUrl;
+	const linkLabel = payload.resultUrl
 		? __( 'Open result', 'frontend-agent-chat' )
 		: __( 'Open preview', 'frontend-agent-chat' );
 
@@ -894,7 +566,6 @@ export default function AgentChat( {
 		description: agentDescription,
 	} ] : [] );
 	const [ selectedAgentSlug, setSelectedAgentSlug ] = useState( agentSlug ?? '' );
-	const metadata = useClientContextMetadata();
 	const selectedAgent = useMemo(
 		() => agents.find( ( agent ) => agent.slug === selectedAgentSlug ),
 		[ agents, selectedAgentSlug ]
@@ -903,9 +574,7 @@ export default function AgentChat( {
 	const activeAgentName = selectedAgent?.name ?? agentName;
 	const activeAgentDescription = selectedAgent?.description ?? agentDescription;
 	const agentFetch = useMemo( () => createAgentFetch( activeAgentSlug ), [ activeAgentSlug ] );
-	const runCapabilities = useMemo( () => createRunCapabilities( capabilities ), [ capabilities ] );
-	const cancelRun = useMemo( () => createCancelRun( agentFetch, basePath ), [ agentFetch, basePath ] );
-	const queueMessage = useMemo( () => createQueueMessage( agentFetch, wpMediaUpload, basePath ), [ agentFetch, basePath ] );
+	const runAdapter = useMemo( () => createFrontendRunAdapter( agentFetch, wpMediaUpload, basePath, capabilities ), [ agentFetch, basePath, capabilities ] );
 	const open = useCallback( () => setIsOpen( true ), [] );
 	const close = useCallback( () => {
 		if ( isInline ) {
@@ -945,12 +614,12 @@ export default function AgentChat( {
 		} );
 		dispatchResponseMetadata( responseMetadata );
 		if ( capabilities?.chat_run_events ) {
-			dispatchRunEvents( agentFetch, basePath, responseMetadata ).catch( ( err: unknown ) => {
+			dispatchRunEvents( runAdapter, responseMetadata ).catch( ( err: unknown ) => {
 				// eslint-disable-next-line no-console
 				console.error( 'AgentChat: failed to fetch chat run events', err );
 			} );
 		}
-	}, [ activeAgentSlug, agentFetch, basePath, capabilities?.chat_run_events ] );
+	}, [ activeAgentSlug, capabilities?.chat_run_events, runAdapter ] );
 
 	useEffect( () => {
 		if ( isInline ) {
@@ -1035,17 +704,29 @@ export default function AgentChat( {
 	}, [ isExpanded, isInline, isOpen ] );
 
 	const toolRenderers = useMemo(
-		() => ( {
-			artifact_phase: renderArtifactStatusCard,
-			start_artifact_generation: renderArtifactStatusCard,
-			artifact_status: renderArtifactStatusCard,
-			artifact_status_update: renderArtifactStatusCard,
-			artifact_task_status: renderArtifactStatusCard,
-			edit_post_blocks: renderDiffCard,
-			replace_post_blocks: renderDiffCard,
-			insert_content: renderDiffCard,
-			present_question: renderQuestionCard,
-		} ),
+		() => {
+			const artifactRenderer = createArtifactStatusToolRenderer( {
+				render: ( payload ) => renderArtifactStatusPayload( payload ),
+				fallback: ( group ) => createElement( ToolMessage, { group } ),
+			} );
+			const diffRenderer = createPendingActionDiffRenderer( {
+				onAccept: ( actionId: string ) => resolvePendingAction( actionId, 'accepted' ),
+				onReject: ( actionId: string ) => resolvePendingAction( actionId, 'rejected' ),
+			} );
+			const questionRenderer = createQuestionToolRenderer();
+
+			return {
+				artifact_phase: artifactRenderer,
+				start_artifact_generation: artifactRenderer,
+				artifact_status: artifactRenderer,
+				artifact_status_update: artifactRenderer,
+				artifact_task_status: artifactRenderer,
+				edit_post_blocks: diffRenderer,
+				replace_post_blocks: diffRenderer,
+				insert_content: diffRenderer,
+				present_question: questionRenderer,
+			};
+		},
 		[]
 	);
 	const hasPersistenceCta = !! (
@@ -1172,7 +853,8 @@ export default function AgentChat( {
 						__( 'Ask %s anything…', 'frontend-agent-chat' ),
 						activeAgentName
 					),
-					metadata,
+					clientContext: true,
+					clientContextOptions: { metadataKey: 'client_context' },
 					onMessage: handleMessage,
 					onError: handleError,
 					onResponseMetadata: handleResponseMetadata,
@@ -1188,10 +870,7 @@ export default function AgentChat( {
 					messageSuggestionsLabel: __( 'Try asking', 'frontend-agent-chat' ),
 					loadingMessages,
 					mediaUploadFn: wpMediaUpload,
-					runCapabilities,
-					getRunId,
-					onCancelRun: cancelRun,
-					onQueueMessage: queueMessage,
+					runAdapter,
 					cancelLabel: __( 'Stop', 'frontend-agent-chat' ),
 					processingLabel: ( turnCount: number ) =>
 						sprintf(

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -161,6 +161,15 @@ interface ArtifactStatusPayload {
 	error?: string;
 }
 
+interface SourceCardPayload {
+	title?: string;
+	url?: string;
+	snippet?: string;
+	documentId?: string;
+	chunkId?: string;
+	accessibleLabel?: string;
+}
+
 const DEFAULT_EXPAND_ICON_PATH = 'M3 8V3h5M21 8V3h-5M3 16v5h5M21 16v5h-5';
 const DEFAULT_COLLAPSE_ICON_PATH = 'M8 3v5H3M16 3v5h5M8 21v-5H3M16 21v-5h5';
 
@@ -455,6 +464,80 @@ function readString( source: Record< string, unknown >, keys: string[] ): string
 	return undefined;
 }
 
+function readSourceCards( source: Record< string, unknown > ): SourceCardPayload[] {
+	const rawSources = source.sources ?? source.citations ?? source.source_cards ?? source.sourceCards;
+	const values = Array.isArray( rawSources ) ? rawSources : rawSources ? [ rawSources ] : [];
+
+	return values
+		.map( normalizeSourceCard )
+		.filter( ( card ): card is SourceCardPayload => !! card );
+}
+
+function normalizeSourceCard( value: unknown ): SourceCardPayload | null {
+	const source = typeof value === 'string' && value.trim()
+		? { url: value.trim() }
+		: asRecord( value );
+	if ( ! source ) {
+		return null;
+	}
+
+	const card: SourceCardPayload = {
+		title: readString( source, [ 'title', 'source_title', 'sourceTitle', 'name', 'label' ] ),
+		url: readString( source, [ 'url', 'source_url', 'sourceUrl', 'href', 'link' ] ),
+		snippet: readString( source, [ 'snippet', 'excerpt', 'summary', 'text', 'content', 'quote' ] ),
+		documentId: readString( source, [ 'document_id', 'documentId', 'doc_id', 'docId', 'document', 'id' ] ),
+		chunkId: readString( source, [ 'chunk_id', 'chunkId', 'chunk', 'chunk_ref', 'chunkRef' ] ),
+		accessibleLabel: readString( source, [ 'accessible_label', 'accessibleLabel', 'aria_label', 'ariaLabel' ] ),
+	};
+
+	return card.title || card.url || card.snippet ? card : null;
+}
+
+function sourceCardHref( url?: string ): string | undefined {
+	if ( ! url ) {
+		return undefined;
+	}
+
+	const trimmed = url.trim();
+	if ( trimmed.startsWith( '/' ) || trimmed.startsWith( '#' ) ) {
+		return trimmed;
+	}
+
+	try {
+		const parsed = new URL( trimmed );
+		return [ 'http:', 'https:' ].includes( parsed.protocol ) ? trimmed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function sourceCardsFromToolGroup( group: ToolGroup ): SourceCardPayload[] {
+	const sources = readSourceCards( group.parameters );
+	const result = group.resultMessage ? parseJsonObject( group.resultMessage.content ) : null;
+	if ( result ) {
+		sources.push( ...readSourceCards( result ) );
+		const nestedResult = asRecord( result.result );
+		if ( nestedResult ) {
+			sources.push( ...readSourceCards( nestedResult ) );
+		}
+		const nestedData = asRecord( result.data );
+		if ( nestedData ) {
+			sources.push( ...readSourceCards( nestedData ) );
+		}
+	}
+
+	const seen = new Set< string >();
+	return sources.filter( ( source ) => {
+		const key = [ source.url, source.title, source.documentId, source.chunkId, source.snippet ].join( '\u0000' );
+		if ( seen.has( key ) ) {
+			return false;
+		}
+
+		seen.add( key );
+		return true;
+	} ).slice( 0, 8 );
+}
+
 function readNumber( source: Record< string, unknown >, keys: string[] ): number | undefined {
 	for ( const key of keys ) {
 		const value = source[ key ];
@@ -712,6 +795,65 @@ function renderQuestionCard( group: ToolGroup, context: ToolRendererContext ): R
 		disabled: context.isLoading,
 		onSubmitAnswer: context.sendMessage,
 	} );
+}
+
+function renderSourceCards( group: ToolGroup ): ReactNode {
+	const sources = sourceCardsFromToolGroup( group );
+	if ( sources.length === 0 ) {
+		return null;
+	}
+
+	return createElement(
+		'section',
+		{ className: 'frontend-agent-chat__source-cards', 'aria-label': __( 'Sources', 'frontend-agent-chat' ) },
+		createElement( 'div', { className: 'frontend-agent-chat__source-cards-title' }, __( 'Sources', 'frontend-agent-chat' ) ),
+		sources.map( ( source, index ) => {
+			const href = sourceCardHref( source.url );
+			const title = source.title ?? source.url ?? sprintf(
+				/* translators: %d: source index. */
+				__( 'Source %d', 'frontend-agent-chat' ),
+				index + 1
+			);
+			const accessibleLabel = source.accessibleLabel ?? sprintf(
+				/* translators: %s: source title. */
+				__( 'Open source: %s', 'frontend-agent-chat' ),
+				title
+			);
+
+			return createElement(
+				'article',
+				{ key: `${ source.url ?? source.title ?? 'source' }-${ index }`, className: 'frontend-agent-chat__source-card' },
+				createElement(
+					'div',
+					{ className: 'frontend-agent-chat__source-card-heading' },
+					href ? createElement(
+						'a',
+						{
+							className: 'frontend-agent-chat__source-card-link',
+							href,
+							target: href.startsWith( '#' ) || href.startsWith( '/' ) ? undefined : '_blank',
+							rel: href.startsWith( '#' ) || href.startsWith( '/' ) ? undefined : 'noopener noreferrer',
+							'aria-label': accessibleLabel,
+						},
+						title
+					) : createElement( 'span', { className: 'frontend-agent-chat__source-card-title' }, title )
+				),
+				source.snippet && createElement( 'p', { className: 'frontend-agent-chat__source-card-snippet' }, source.snippet ),
+				( source.documentId || source.chunkId ) && createElement(
+					'dl',
+					{ className: 'frontend-agent-chat__source-card-debug' },
+					source.documentId && createElement( 'div', null,
+						createElement( 'dt', null, __( 'Document', 'frontend-agent-chat' ) ),
+						createElement( 'dd', null, source.documentId )
+					),
+					source.chunkId && createElement( 'div', null,
+						createElement( 'dt', null, __( 'Chunk', 'frontend-agent-chat' ) ),
+						createElement( 'dd', null, source.chunkId )
+					)
+				)
+			);
+		} )
+	);
 }
 
 function artifactStatusLabel( status: ArtifactPhaseStatus ): string {
@@ -1036,6 +1178,9 @@ export default function AgentChat( {
 
 	const toolRenderers = useMemo(
 		() => ( {
+			source_cards: renderSourceCards,
+			sources: renderSourceCards,
+			citations: renderSourceCards,
 			artifact_phase: renderArtifactStatusCard,
 			start_artifact_generation: renderArtifactStatusCard,
 			artifact_status: renderArtifactStatusCard,

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -456,6 +456,86 @@
 	text-decoration: underline;
 }
 
+.frontend-agent-chat__source-cards {
+	margin: 8px 12px;
+	font-family: var(--frontend-agent-chat-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+	color: var(--frontend-agent-chat-text-primary, #1e293b);
+}
+
+.frontend-agent-chat__source-cards-title {
+	margin: 0 0 6px;
+	color: var(--frontend-agent-chat-text-muted, #64748b);
+	font-size: 12px;
+	font-weight: 700;
+	line-height: 1.3;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+.frontend-agent-chat__source-card {
+	padding: 10px 12px;
+	border: 1px solid var(--frontend-agent-chat-border-color, #e2e8f0);
+	border-radius: 12px;
+	background: var(--frontend-agent-chat-message-bg, #fff);
+	box-shadow: 0 1px 3px rgba(15, 23, 42, 0.06);
+}
+
+.frontend-agent-chat__source-card + .frontend-agent-chat__source-card {
+	margin-top: 8px;
+}
+
+.frontend-agent-chat__source-card-heading {
+	font-size: 13px;
+	font-weight: 700;
+	line-height: 1.35;
+}
+
+.frontend-agent-chat__source-card-link {
+	color: var(--frontend-agent-chat-accent, #2563eb);
+	text-decoration: none;
+}
+
+.frontend-agent-chat__source-card-link:hover {
+	text-decoration: underline;
+}
+
+.frontend-agent-chat__source-card-title {
+	color: var(--frontend-agent-chat-text-primary, #1e293b);
+}
+
+.frontend-agent-chat__source-card-snippet {
+	margin: 6px 0 0;
+	color: var(--frontend-agent-chat-text-muted, #64748b);
+	font-size: 12px;
+	line-height: 1.45;
+}
+
+.frontend-agent-chat__source-card-debug {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px 10px;
+	margin: 8px 0 0;
+	color: var(--frontend-agent-chat-text-muted, #64748b);
+	font-family: var(--frontend-agent-chat-monospace-font-family, ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', monospace);
+	font-size: 11px;
+	line-height: 1.35;
+}
+
+.frontend-agent-chat__source-card-debug div {
+	display: inline-flex;
+	gap: 4px;
+	min-width: 0;
+}
+
+.frontend-agent-chat__source-card-debug dt,
+.frontend-agent-chat__source-card-debug dd {
+	margin: 0;
+}
+
+.frontend-agent-chat__source-card-debug dt {
+	font-weight: 700;
+}
+
 .frontend-agent-chat__empty {
 	text-align: center;
 	padding: var(--frontend-agent-chat-spacing-lg, 24px);

--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,0 +1,2 @@
+declare module '*.css';
+declare module '@extrachill/chat/css';

--- a/tests/source-cards-message-metadata-smoke.php
+++ b/tests/source-cards-message-metadata-smoke.php
@@ -35,8 +35,9 @@ $messages = frontend_agent_chat_session_messages(
 							'title'       => 'Public docs',
 							'url'         => 'https://example.com/docs',
 							'snippet'     => 'A short excerpt from the source.',
-							'document_id' => 'doc-123',
-							'chunk_id'    => 'chunk-4',
+							'source_id'   => 'source-1',
+							'item_id'     => 'item-123',
+							'fragment_id' => 'fragment-4',
 						),
 					),
 				),
@@ -51,11 +52,12 @@ frontend_agent_chat_source_cards_assert( 'tool_call' === ( $messages[1]['metadat
 frontend_agent_chat_source_cards_assert( 'source_cards' === ( $messages[1]['metadata']['tool_name'] ?? '' ), 'Source-card tool name is generic.' );
 frontend_agent_chat_source_cards_assert( 'Public docs' === ( $messages[1]['metadata']['parameters']['sources'][0]['title'] ?? '' ), 'Source title is normalized.' );
 frontend_agent_chat_source_cards_assert( 'https://example.com/docs' === ( $messages[1]['metadata']['parameters']['sources'][0]['url'] ?? '' ), 'Source URL is normalized.' );
-frontend_agent_chat_source_cards_assert( 'doc-123' === ( $messages[1]['metadata']['parameters']['sources'][0]['document_id'] ?? '' ), 'Document id is preserved.' );
+frontend_agent_chat_source_cards_assert( 'source-1' === ( $messages[1]['metadata']['parameters']['sources'][0]['source_id'] ?? '' ), 'Source id is preserved.' );
+frontend_agent_chat_source_cards_assert( 'item-123' === ( $messages[1]['metadata']['parameters']['sources'][0]['item_id'] ?? '' ), 'Item id is preserved.' );
 frontend_agent_chat_source_cards_assert( 'tool_result' === ( $messages[2]['metadata']['type'] ?? '' ), 'Source cards include a tool result envelope.' );
 
 $tool_result = json_decode( (string) $messages[2]['content'], true );
 frontend_agent_chat_source_cards_assert( is_array( $tool_result ), 'Source-card result content is JSON.' );
-frontend_agent_chat_source_cards_assert( 'chunk-4' === ( $tool_result['sources'][0]['chunk_id'] ?? '' ), 'Chunk id survives session reload result payload.' );
+frontend_agent_chat_source_cards_assert( 'fragment-4' === ( $tool_result['sources'][0]['fragment_id'] ?? '' ), 'Fragment id survives session reload result payload.' );
 
-echo "Frontend source-card metadata smoke passed (9 assertions).\n";
+echo "Frontend source-card metadata smoke passed (11 assertions).\n";

--- a/tests/source-cards-message-metadata-smoke.php
+++ b/tests/source-cards-message-metadata-smoke.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Smoke tests for citation/source-card message metadata normalization.
+ *
+ * @package FrontendAgentChat\Tests
+ */
+
+function frontend_agent_chat_source_cards_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		return true;
+	}
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/rest.php';
+
+$messages = frontend_agent_chat_session_messages(
+	array(
+		'messages' => array(
+			array(
+				'role'     => 'assistant',
+				'content'  => 'Here is the answer.',
+				'metadata' => array(
+					'citations' => array(
+						array(
+							'title'       => 'Public docs',
+							'url'         => 'https://example.com/docs',
+							'snippet'     => 'A short excerpt from the source.',
+							'document_id' => 'doc-123',
+							'chunk_id'    => 'chunk-4',
+						),
+					),
+				),
+			),
+		),
+	)
+);
+
+frontend_agent_chat_source_cards_assert( 3 === count( $messages ), 'Citation metadata should add a source-card tool pair.' );
+frontend_agent_chat_source_cards_assert( 'assistant' === $messages[0]['role'], 'Original assistant message remains first.' );
+frontend_agent_chat_source_cards_assert( 'tool_call' === ( $messages[1]['metadata']['type'] ?? '' ), 'Source cards include a tool call envelope.' );
+frontend_agent_chat_source_cards_assert( 'source_cards' === ( $messages[1]['metadata']['tool_name'] ?? '' ), 'Source-card tool name is generic.' );
+frontend_agent_chat_source_cards_assert( 'Public docs' === ( $messages[1]['metadata']['parameters']['sources'][0]['title'] ?? '' ), 'Source title is normalized.' );
+frontend_agent_chat_source_cards_assert( 'https://example.com/docs' === ( $messages[1]['metadata']['parameters']['sources'][0]['url'] ?? '' ), 'Source URL is normalized.' );
+frontend_agent_chat_source_cards_assert( 'doc-123' === ( $messages[1]['metadata']['parameters']['sources'][0]['document_id'] ?? '' ), 'Document id is preserved.' );
+frontend_agent_chat_source_cards_assert( 'tool_result' === ( $messages[2]['metadata']['type'] ?? '' ), 'Source cards include a tool result envelope.' );
+
+$tool_result = json_decode( (string) $messages[2]['content'], true );
+frontend_agent_chat_source_cards_assert( is_array( $tool_result ), 'Source-card result content is JSON.' );
+frontend_agent_chat_source_cards_assert( 'chunk-4' === ( $tool_result['sources'][0]['chunk_id'] ?? '' ), 'Chunk id survives session reload result payload.' );
+
+echo "Frontend source-card metadata smoke passed (9 assertions).\n";


### PR DESCRIPTION
## Summary
- Adds generic source/citation card rendering for chat messages via metadata-driven `source_cards` tool envelopes.
- Normalizes common citation metadata keys (`sources`, `citations`, `source_cards`, `sourceCards`) so source cards survive session reloads.
- Aligns with the Agents API generic citation contract by rendering `source_id`, `item_id`, and `fragment_id` identifiers instead of product-specific document/chunk canonical fields.
- Supports source titles, safe clickable URLs, snippets, generic citation identifiers, and accessible link labels.

Fixes https://github.com/Automattic/frontend-agent-chat/issues/68

## Testing
- `npm run typecheck`
- `npm run build`
- `php tests/tool-transcript-message-filter-smoke.php`
- `php tests/source-cards-message-metadata-smoke.php`
- `php tests/run-control-smoke.php`
- `php tests/principal-access-smoke.php`

## Boundary review
- Checked this PR against Automattic/agents-api#297, Automattic/agents-api#298, and Automattic/agents-api#299.
- Frontend Agent Chat only renders generic citation metadata and does not introduce brain, corpus, indexing, embedding, retrieval-engine, ontology, or product-specific semantics.
- Product-owned document/chunk fields are accepted only as input aliases and normalized into the generic `item_id` / `fragment_id` display shape.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, boundary cleanup, smoke test, and PR description; Chris remains responsible for review and validation.