### PR TITLE
Add retrieval diagnostics panel

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -26,9 +26,10 @@ function frontend_agent_chat_get_config(): array {
 		'expand_icon_path'     => '',
 		'collapse_icon_path'   => '',
 		'expand_icon_view_box' => '0 0 24 24',
-		'loading_messages'     => true,
-		'message_suggestions'  => array(),
-		'layout'               => 'floating',
+		'loading_messages'      => true,
+		'message_suggestions'   => array(),
+		'retrieval_diagnostics' => false,
+		'layout'                => 'floating',
 	);
 
 	$saved = get_option( 'frontend_agent_chat_config', array() );
@@ -464,21 +465,23 @@ function frontend_agent_chat_has_ability( string $name ): bool {
  * Detect run-control support for the current frontend chat principal.
  *
  * @param string $agent_slug Optional selected agent slug.
- * @return array{chat_run_status:bool,chat_run_cancel:bool,chat_message_queue:bool,chat_run_events:bool}
+ * @return array{chat_run_status:bool,chat_run_cancel:bool,chat_message_queue:bool,chat_run_events:bool,retrieval_diagnostics:bool}
  */
 function frontend_agent_chat_get_run_control_capabilities( string $agent_slug = '' ): array {
 	$agent_slug = sanitize_title( $agent_slug );
 	$can_chat   = true;
+	$config     = frontend_agent_chat_get_config();
 
 	if ( '' !== $agent_slug ) {
 		$can_chat = frontend_agent_chat_user_can_see( frontend_agent_chat_resolve_agent( $agent_slug ) );
 	}
 
 	$capabilities = array(
-		'chat_run_status'    => $can_chat && frontend_agent_chat_has_ability( 'agents/get-chat-run' ),
-		'chat_run_cancel'    => $can_chat && frontend_agent_chat_has_ability( 'agents/cancel-chat-run' ),
-		'chat_message_queue' => $can_chat && frontend_agent_chat_has_ability( 'agents/queue-chat-message' ),
-		'chat_run_events'    => $can_chat && frontend_agent_chat_has_ability( 'agents/list-chat-run-events' ),
+		'chat_run_status'       => $can_chat && frontend_agent_chat_has_ability( 'agents/get-chat-run' ),
+		'chat_run_cancel'       => $can_chat && frontend_agent_chat_has_ability( 'agents/cancel-chat-run' ),
+		'chat_message_queue'    => $can_chat && frontend_agent_chat_has_ability( 'agents/queue-chat-message' ),
+		'chat_run_events'       => $can_chat && frontend_agent_chat_has_ability( 'agents/list-chat-run-events' ),
+		'retrieval_diagnostics' => $can_chat && ! empty( $config['retrieval_diagnostics'] ),
 	);
 
 	/**
@@ -491,10 +494,11 @@ function frontend_agent_chat_get_run_control_capabilities( string $agent_slug = 
 	$filtered = apply_filters( 'frontend_agent_chat_run_control_capabilities', $capabilities, $agent_slug );
 
 	return is_array( $filtered ) ? array(
-		'chat_run_status'    => ! empty( $filtered['chat_run_status'] ),
-		'chat_run_cancel'    => ! empty( $filtered['chat_run_cancel'] ),
-		'chat_message_queue' => ! empty( $filtered['chat_message_queue'] ),
-		'chat_run_events'    => ! empty( $filtered['chat_run_events'] ),
+		'chat_run_status'       => ! empty( $filtered['chat_run_status'] ),
+		'chat_run_cancel'       => ! empty( $filtered['chat_run_cancel'] ),
+		'chat_message_queue'    => ! empty( $filtered['chat_message_queue'] ),
+		'chat_run_events'       => ! empty( $filtered['chat_run_events'] ),
+		'retrieval_diagnostics' => ! empty( $filtered['retrieval_diagnostics'] ),
 	) : $capabilities;
 }
 

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -139,23 +139,26 @@ function frontend_agent_chat_enqueue() {
 		);
 	}
 
+	$capabilities = frontend_agent_chat_get_run_control_capabilities( (string) ( $agent['agent_slug'] ?? $default_agent_slug ) );
+
 	$js_config = array(
-		'agentSlug'         => (string) ( $agent['agent_slug'] ?? $default_agent_slug ),
-		'basePath'          => '/frontend-agent-chat/v1/chat',
-		'bootstrapPath'     => '/frontend-agent-chat/v1/bootstrap',
-		'agentsPath'        => '/frontend-agent-chat/v1/agents',
-		'agentName'         => (string) ( $agent['agent_name'] ?? $agent['label'] ?? $default_agent_slug ),
-		'agentDescription'  => (string) ( $agent['agent_description'] ?? $agent['description'] ?? $config['description'] ),
-		'fabLabel'          => sanitize_text_field( (string) ( $config['fab_label'] ?? __( 'Agent Chat', 'frontend-agent-chat' ) ) ),
-		'fabIcon'           => sanitize_text_field( (string) ( $config['fab_icon'] ?? 'AI' ) ),
-		'fabIconPath'       => frontend_agent_chat_sanitize_svg_path( $config['fab_icon_path'] ?? '' ),
-		'fabIconViewBox'    => frontend_agent_chat_sanitize_svg_view_box( $config['fab_icon_view_box'] ?? '0 0 24 24' ),
-		'expandIconPath'    => frontend_agent_chat_sanitize_svg_path( $config['expand_icon_path'] ?? '' ),
-		'collapseIconPath'  => frontend_agent_chat_sanitize_svg_path( $config['collapse_icon_path'] ?? '' ),
-		'expandIconViewBox' => frontend_agent_chat_sanitize_svg_view_box( $config['expand_icon_view_box'] ?? '0 0 24 24' ),
-		'layout'            => 'inline' === ( $config['layout'] ?? '' ) ? 'inline' : 'floating',
-		'isLoggedIn'        => is_user_logged_in(),
-		'capabilities'      => frontend_agent_chat_get_run_control_capabilities( (string) ( $agent['agent_slug'] ?? $default_agent_slug ) ),
+		'agentSlug'                   => (string) ( $agent['agent_slug'] ?? $default_agent_slug ),
+		'basePath'                    => '/frontend-agent-chat/v1/chat',
+		'bootstrapPath'               => '/frontend-agent-chat/v1/bootstrap',
+		'agentsPath'                  => '/frontend-agent-chat/v1/agents',
+		'agentName'                   => (string) ( $agent['agent_name'] ?? $agent['label'] ?? $default_agent_slug ),
+		'agentDescription'            => (string) ( $agent['agent_description'] ?? $agent['description'] ?? $config['description'] ),
+		'fabLabel'                    => sanitize_text_field( (string) ( $config['fab_label'] ?? __( 'Agent Chat', 'frontend-agent-chat' ) ) ),
+		'fabIcon'                     => sanitize_text_field( (string) ( $config['fab_icon'] ?? 'AI' ) ),
+		'fabIconPath'                 => frontend_agent_chat_sanitize_svg_path( $config['fab_icon_path'] ?? '' ),
+		'fabIconViewBox'              => frontend_agent_chat_sanitize_svg_view_box( $config['fab_icon_view_box'] ?? '0 0 24 24' ),
+		'expandIconPath'              => frontend_agent_chat_sanitize_svg_path( $config['expand_icon_path'] ?? '' ),
+		'collapseIconPath'            => frontend_agent_chat_sanitize_svg_path( $config['collapse_icon_path'] ?? '' ),
+		'expandIconViewBox'           => frontend_agent_chat_sanitize_svg_view_box( $config['expand_icon_view_box'] ?? '0 0 24 24' ),
+		'layout'                      => 'inline' === ( $config['layout'] ?? '' ) ? 'inline' : 'floating',
+		'isLoggedIn'                  => is_user_logged_in(),
+		'capabilities'                => $capabilities,
+		'retrievalDiagnosticsEnabled' => ! empty( $config['retrieval_diagnostics'] ) || ! empty( $capabilities['retrieval_diagnostics'] ),
 	);
 
 	/**

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"private": true,
 	"scripts": {
 		"build": "wp-scripts build",
+		"test:diagnostics": "node --no-warnings --experimental-strip-types tests/retrieval-diagnostics-smoke.ts",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -27,6 +27,7 @@ import {
 } from '@extrachill/chat';
 import type { ChatMessage, ChatMessageSuggestion, ToolGroup, DiffData, FetchFn, MediaUploadFn, ToolRendererContext, QuestionChoice, ChatRunCapabilities, CancelRunInput, QueueMessageInput, QueueMessageResult } from '@extrachill/chat';
 import type { ChangeEvent, ReactNode } from 'react';
+import { getRetrievalDiagnosticsPanel, shouldRenderRetrievalDiagnostics } from './retrieval-diagnostics';
 
 /**
  * WordPress dependencies
@@ -67,7 +68,9 @@ interface AgentChatProps {
 		chat_run_cancel?: boolean;
 		chat_message_queue?: boolean;
 		chat_run_events?: boolean;
+		retrieval_diagnostics?: boolean;
 	};
+	retrievalDiagnosticsEnabled?: boolean;
 }
 
 interface BootstrapResponse {
@@ -818,6 +821,33 @@ function renderArtifactStatusCard( group: ToolGroup ): ReactNode {
 	);
 }
 
+function renderRetrievalDiagnosticsPanel( metadata: Record< string, unknown > | null ): ReactNode {
+	if ( ! metadata ) {
+		return null;
+	}
+
+	const panel = getRetrievalDiagnosticsPanel( metadata );
+	if ( ! panel ) {
+		return null;
+	}
+
+	return createElement(
+		'details',
+		{ className: 'frontend-agent-chat__retrieval-diagnostics' },
+		createElement( 'summary', null, __( 'Retrieval diagnostics', 'frontend-agent-chat' ) ),
+		createElement(
+			'dl',
+			null,
+			panel.rows.map( ( row ) => createElement(
+				'div',
+				{ key: row.label, className: 'frontend-agent-chat__retrieval-diagnostics-row' },
+				createElement( 'dt', null, row.label ),
+				createElement( 'dd', null, row.value )
+			) )
+		)
+	);
+}
+
 function renderExpandIcon( path: string, viewBox: string ): ReactNode {
 	return createElement(
 		'svg',
@@ -881,6 +911,7 @@ export default function AgentChat( {
 	persistenceCta,
 	messageSuggestions,
 	capabilities,
+	retrievalDiagnosticsEnabled,
 }: AgentChatProps ) {
 	const isInline = layout === 'inline';
 	const [ isOpen, setIsOpen ] = useState( isInline );
@@ -888,6 +919,7 @@ export default function AgentChat( {
 	const [ unreadCount, setUnreadCount ] = useState( 0 );
 	const [ browserBootstrapReady, setBrowserBootstrapReady ] = useState( isLoggedIn );
 	const [ browserBootstrapFailed, setBrowserBootstrapFailed ] = useState( false );
+	const [ retrievalDiagnosticsMetadata, setRetrievalDiagnosticsMetadata ] = useState< Record< string, unknown > | null >( null );
 	const [ agents, setAgents ] = useState< AgentSummary[] >( () => agentSlug ? [ {
 		slug: agentSlug,
 		name: agentName,
@@ -904,6 +936,7 @@ export default function AgentChat( {
 	const activeAgentDescription = selectedAgent?.description ?? agentDescription;
 	const agentFetch = useMemo( () => createAgentFetch( activeAgentSlug ), [ activeAgentSlug ] );
 	const runCapabilities = useMemo( () => createRunCapabilities( capabilities ), [ capabilities ] );
+	const canShowRetrievalDiagnostics = !! retrievalDiagnosticsEnabled || !! capabilities?.retrieval_diagnostics;
 	const cancelRun = useMemo( () => createCancelRun( agentFetch, basePath ), [ agentFetch, basePath ] );
 	const queueMessage = useMemo( () => createQueueMessage( agentFetch, wpMediaUpload, basePath ), [ agentFetch, basePath ] );
 	const open = useCallback( () => setIsOpen( true ), [] );
@@ -944,13 +977,18 @@ export default function AgentChat( {
 			metadata: responseMetadata,
 		} );
 		dispatchResponseMetadata( responseMetadata );
+		setRetrievalDiagnosticsMetadata(
+			shouldRenderRetrievalDiagnostics( canShowRetrievalDiagnostics, responseMetadata )
+				? responseMetadata
+				: null
+		);
 		if ( capabilities?.chat_run_events ) {
 			dispatchRunEvents( agentFetch, basePath, responseMetadata ).catch( ( err: unknown ) => {
 				// eslint-disable-next-line no-console
 				console.error( 'AgentChat: failed to fetch chat run events', err );
 			} );
 		}
-	}, [ activeAgentSlug, agentFetch, basePath, capabilities?.chat_run_events ] );
+	}, [ activeAgentSlug, agentFetch, basePath, canShowRetrievalDiagnostics, capabilities?.chat_run_events ] );
 
 	useEffect( () => {
 		if ( isInline ) {
@@ -1188,6 +1226,9 @@ export default function AgentChat( {
 					messageSuggestionsLabel: __( 'Try asking', 'frontend-agent-chat' ),
 					loadingMessages,
 					mediaUploadFn: wpMediaUpload,
+					renderHeader: () => canShowRetrievalDiagnostics
+						? renderRetrievalDiagnosticsPanel( retrievalDiagnosticsMetadata )
+						: null,
 					runCapabilities,
 					getRunId,
 					onCancelRun: cancelRun,

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -208,6 +208,45 @@
 	outline-offset: 2px;
 }
 
+.frontend-agent-chat__retrieval-diagnostics {
+	margin: var(--frontend-agent-chat-spacing-sm, 12px) var(--frontend-agent-chat-spacing-md, 16px) 0;
+	padding: var(--frontend-agent-chat-spacing-sm, 12px);
+	border: 1px solid var(--frontend-agent-chat-border-color, #e2e8f0);
+	border-radius: 12px;
+	background: var(--frontend-agent-chat-bg-muted, #f8fafc);
+	color: var(--frontend-agent-chat-text-primary, #1e293b);
+	font-family: var(--frontend-agent-chat-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+	font-size: 12px;
+}
+
+.frontend-agent-chat__retrieval-diagnostics summary {
+	cursor: pointer;
+	font-weight: 700;
+}
+
+.frontend-agent-chat__retrieval-diagnostics dl {
+	display: grid;
+	gap: 8px;
+	margin: 10px 0 0;
+}
+
+.frontend-agent-chat__retrieval-diagnostics-row {
+	display: grid;
+	grid-template-columns: minmax(96px, 0.35fr) 1fr;
+	gap: 8px;
+}
+
+.frontend-agent-chat__retrieval-diagnostics dt {
+	color: var(--frontend-agent-chat-text-secondary, #64748b);
+	font-weight: 700;
+}
+
+.frontend-agent-chat__retrieval-diagnostics dd {
+	min-width: 0;
+	margin: 0;
+	overflow-wrap: anywhere;
+}
+
 .frontend-agent-chat__header-actions {
 	display: flex;
 	align-items: center;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,9 @@ declare global {
 				chat_run_cancel?: boolean;
 				chat_message_queue?: boolean;
 				chat_run_events?: boolean;
+				retrieval_diagnostics?: boolean;
 			};
+			retrievalDiagnosticsEnabled?: boolean;
 		};
 	}
 }
@@ -111,6 +113,7 @@ function init(): void {
 			persistenceCta: config.persistenceCta,
 			messageSuggestions: config.messageSuggestions,
 			capabilities: config.capabilities,
+			retrievalDiagnosticsEnabled: config.retrievalDiagnosticsEnabled,
 		} )
 	);
 }

--- a/src/retrieval-diagnostics.ts
+++ b/src/retrieval-diagnostics.ts
@@ -1,0 +1,118 @@
+export interface RetrievalDiagnosticsRow {
+	label: string;
+	value: string;
+}
+
+export interface RetrievalDiagnosticsPanel {
+	title: string;
+	rows: RetrievalDiagnosticsRow[];
+}
+
+const DIAGNOSTICS_KEYS = [
+	'retrieval_diagnostics',
+	'retrievalDiagnostics',
+	'retrieval_metadata',
+	'retrievalMetadata',
+	'retrieval',
+];
+
+const FIELD_MAP: Array< { label: string; keys: string[] } > = [
+	{ label: 'Mode', keys: [ 'mode', 'retrieval_mode', 'retrievalMode', 'search_mode', 'searchMode' ] },
+	{ label: 'Corpus', keys: [ 'corpus', 'corpus_id', 'corpusId', 'knowledge_base', 'knowledgeBase', 'knowledge_base_id', 'knowledgeBaseId', 'index', 'collection' ] },
+	{ label: 'Results', keys: [ 'result_count', 'resultCount', 'results_count', 'resultsCount', 'count', 'total' ] },
+	{ label: 'Provider errors', keys: [ 'provider_errors', 'providerErrors', 'errors', 'error' ] },
+	{ label: 'Excluded sources', keys: [ 'excluded_sources_summary', 'excludedSourcesSummary', 'excluded_sources', 'excludedSources', 'excluded' ] },
+	{ label: 'Scores', keys: [ 'score_details', 'scoreDetails', 'scores', 'score' ] },
+];
+
+function asRecord( value: unknown ): Record< string, unknown > | null {
+	return value && typeof value === 'object' && ! Array.isArray( value )
+		? value as Record< string, unknown >
+		: null;
+}
+
+function hasAnyDiagnosticsField( source: Record< string, unknown > ): boolean {
+	return FIELD_MAP.some( ( field ) => field.keys.some( ( key ) => source[ key ] !== undefined && source[ key ] !== null ) );
+}
+
+function findDiagnosticsSource( metadata: Record< string, unknown > ): Record< string, unknown > | null {
+	for ( const key of DIAGNOSTICS_KEYS ) {
+		const source = asRecord( metadata[ key ] );
+		if ( source ) {
+			return source;
+		}
+	}
+
+	return hasAnyDiagnosticsField( metadata ) ? metadata : null;
+}
+
+function stringifyValue( value: unknown ): string {
+	if ( typeof value === 'string' ) {
+		return value.trim();
+	}
+
+	if ( typeof value === 'number' || typeof value === 'boolean' ) {
+		return String( value );
+	}
+
+	if ( Array.isArray( value ) ) {
+		return value
+			.map( stringifyValue )
+			.filter( Boolean )
+			.join( ', ' );
+	}
+
+	if ( value && typeof value === 'object' ) {
+		try {
+			return JSON.stringify( value );
+		} catch {
+			return '';
+		}
+	}
+
+	return '';
+}
+
+function readDiagnosticValue( source: Record< string, unknown >, keys: string[] ): string {
+	for ( const key of keys ) {
+		const value = source[ key ];
+		if ( value === undefined || value === null ) {
+			continue;
+		}
+
+		const rendered = stringifyValue( value );
+		if ( rendered ) {
+			return rendered;
+		}
+	}
+
+	return '';
+}
+
+export function getRetrievalDiagnosticsRows( metadata: Record< string, unknown > ): RetrievalDiagnosticsRow[] {
+	const source = findDiagnosticsSource( metadata );
+	if ( ! source ) {
+		return [];
+	}
+
+	return FIELD_MAP.map( ( field ) => ( {
+		label: field.label,
+		value: readDiagnosticValue( source, field.keys ),
+	} ) ).filter( ( row ) => row.value !== '' );
+}
+
+export function getRetrievalDiagnosticsPanel( metadata: Record< string, unknown > ): RetrievalDiagnosticsPanel | null {
+	const rows = getRetrievalDiagnosticsRows( metadata );
+	if ( rows.length === 0 ) {
+		return null;
+	}
+
+	return {
+		title: 'Retrieval diagnostics',
+		rows,
+	};
+}
+
+export function shouldRenderRetrievalDiagnostics( enabled: boolean, metadata: Record< string, unknown > | null | undefined ): boolean {
+	return enabled && !! metadata && getRetrievalDiagnosticsRows( metadata ).length > 0;
+}

--- a/tests/retrieval-diagnostics-smoke.ts
+++ b/tests/retrieval-diagnostics-smoke.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import {
+	getRetrievalDiagnosticsRows,
+	shouldRenderRetrievalDiagnostics,
+} from '../src/retrieval-diagnostics.ts';
+
+const metadata = {
+	retrieval_diagnostics: {
+		mode: 'semantic',
+		knowledge_base: 'docs',
+		result_count: 3,
+		provider_errors: [ 'timeout' ],
+		excluded_sources_summary: '2 stale entries',
+		score_details: { top: 0.91 },
+	},
+};
+
+assert.equal(
+	shouldRenderRetrievalDiagnostics( false, metadata ),
+	false,
+	'diagnostics stay hidden when the operator gate is disabled'
+);
+
+assert.equal(
+	shouldRenderRetrievalDiagnostics( true, {} ),
+	false,
+	'diagnostics stay hidden when response metadata has no retrieval fields'
+);
+
+assert.equal(
+	shouldRenderRetrievalDiagnostics( true, metadata ),
+	true,
+	'diagnostics render when the operator gate is enabled and retrieval metadata exists'
+);
+
+assert.deepEqual(
+	getRetrievalDiagnosticsRows( metadata ).map( ( row ) => row.label ),
+	[ 'Mode', 'Corpus', 'Results', 'Provider errors', 'Excluded sources', 'Scores' ],
+	'generic retrieval diagnostics rows are normalized without provider-specific fields'
+);
+
+console.log( 'Frontend retrieval diagnostics smoke passed (4 assertions).' );

--- a/tests/run-control-smoke.php
+++ b/tests/run-control-smoke.php
@@ -139,7 +139,11 @@ function sanitize_key( $value ) {
 }
 
 function apply_filters( $hook, $value ) {
-	unset( $hook );
+	if ( 'frontend_agent_chat_run_control_capabilities' === $hook && is_callable( $GLOBALS['frontend_agent_chat_run_control_capabilities_filter'] ?? null ) ) {
+		$args = func_get_args();
+		return $GLOBALS['frontend_agent_chat_run_control_capabilities_filter']( $value, $args[2] ?? '' );
+	}
+
 	return $value;
 }
 
@@ -148,7 +152,10 @@ function register_rest_route() {}
 function add_filter() {}
 
 function get_option( $name, $default = false ) {
-	unset( $name );
+	if ( 'frontend_agent_chat_config' === $name ) {
+		return $GLOBALS['frontend_agent_chat_run_control_config'] ?? $default;
+	}
+
 	return $default;
 }
 
@@ -214,6 +221,7 @@ $GLOBALS['frontend_agent_chat_run_control_agents'] = array(
 		'description' => 'Answers user questions.',
 	),
 );
+$GLOBALS['frontend_agent_chat_run_control_config'] = array();
 $GLOBALS['frontend_agent_chat_run_control_abilities'] = array(
 	'agents/list-accessible-agents',
 	'agents/can-access-agent',
@@ -230,7 +238,21 @@ frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_sta
 frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_cancel'], 'cancel capability requires canonical ability', $failures, $passes );
 frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_message_queue'], 'queue capability requires canonical ability', $failures, $passes );
 frontend_agent_chat_run_control_assert_equals( true, $capabilities['chat_run_events'], 'events capability requires canonical ability', $failures, $passes );
+frontend_agent_chat_run_control_assert_equals( false, $capabilities['retrieval_diagnostics'], 'retrieval diagnostics are hidden by default', $failures, $passes );
 frontend_agent_chat_run_control_assert_equals( 'agents/list-accessible-agents', $GLOBALS['frontend_agent_chat_run_control_calls'][0][0] ?? '', 'capability detection checks selected agent access', $failures, $passes );
+
+$GLOBALS['frontend_agent_chat_run_control_capabilities_filter'] = static function ( array $capabilities ): array {
+	$capabilities['retrieval_diagnostics'] = true;
+	return $capabilities;
+};
+$capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['retrieval_diagnostics'], 'retrieval diagnostics can be enabled by capability filter', $failures, $passes );
+unset( $GLOBALS['frontend_agent_chat_run_control_capabilities_filter'] );
+
+$GLOBALS['frontend_agent_chat_run_control_config'] = array( 'retrieval_diagnostics' => true );
+$capabilities = frontend_agent_chat_get_run_control_capabilities( 'demo-agent' );
+frontend_agent_chat_run_control_assert_equals( true, $capabilities['retrieval_diagnostics'], 'retrieval diagnostics can be enabled by config', $failures, $passes );
+$GLOBALS['frontend_agent_chat_run_control_config'] = array();
 
 $run_response = frontend_agent_chat_rest_get_run( new WP_REST_Request( array( 'run_id' => 'run-1', 'session_id' => 'session-1', 'agent' => 'demo-agent' ) ) );
 frontend_agent_chat_run_control_assert_equals( 'running', $run_response['data']['status'] ?? '', 'run status is normalized', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add a generic opt-in retrieval diagnostics panel that renders latest response metadata only when enabled by config or capability.
- Normalize common retrieval metadata fields without coupling the UI to a specific retrieval provider.
- Cover hidden/visible diagnostics states in PHP capability smoke tests and a Node diagnostics smoke test.

Closes https://github.com/Automattic/frontend-agent-chat/issues/70

## Testing
- `npm run build`
- `npm run typecheck`
- `npm run test:diagnostics`
- `php tests/run-control-smoke.php`
- `php tests/principal-access-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the diagnostics rendering/config/test changes; Chris remains responsible for review and validation.