### PR TITLE
build: bump @extrachill/chat to v0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat#v0.13.0"
+				"@extrachill/chat": "github:Extra-Chill/chat#v0.14.0"
 			},
 			"devDependencies": {
 				"@types/wordpress__block-editor": "^15.0.5",
@@ -2656,8 +2656,8 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.13.0",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#51389ced7d6996740d5c3e512641390806707a33",
+			"version": "0.14.0",
+			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#11825557d9368aa2c25bdc77c57848f4af8cdcf6",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat#v0.13.0"
+		"@extrachill/chat": "github:Extra-Chill/chat#v0.14.0"
 	},
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^15.0.5",


### PR DESCRIPTION
## Summary

Bumps the `@extrachill/chat` dependency from **v0.13.0 → v0.14.0**.

Chat v0.14.0 release: https://github.com/Extra-Chill/chat/releases/tag/v0.14.0

It adds adapter-first chat envelope, citation rendering primitives, reusable tool renderer factories, tool timeline primitives, a floating chat shell, and run-control adapter primitives.

## Changes

- `package.json`: `github:Extra-Chill/chat#v0.13.0` → `github:Extra-Chill/chat#v0.14.0`
- `package-lock.json`: resolved git ref updated to v0.14.0 tag (`11825557d9368aa2c25bdc77c57848f4af8cdcf6`), version `0.14.0`
- Confirmed `node_modules/@extrachill/chat/package.json` reports version `0.14.0`

## Consumer code changes

**No consumer changes needed.** The new package API (envelope/adapter/citation/tool-renderer/run-control primitives) is backward-compatible with this consumer — `tsc --noEmit` and `wp-scripts build` both pass against the new exports with zero source edits.

## Check status

| Check | Status |
|-------|--------|
| `npm run typecheck` (`tsc --noEmit`) | ✅ pass |
| `npm run build` (`wp-scripts build`) | ✅ compiled successfully |
| `homeboy lint --extension nodejs` | ✅ passed, 0 findings |