### PR TITLE
Support brain-aware chat metadata

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -28,6 +28,7 @@ function frontend_agent_chat_get_config(): array {
 		'expand_icon_view_box' => '0 0 24 24',
 		'loading_messages'     => true,
 		'message_suggestions'  => array(),
+		'chat_context'         => array(),
 		'operator_diagnostics' => false,
 		'layout'               => 'floating',
 	);

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -85,6 +85,54 @@ function frontend_agent_chat_sanitize_message_suggestions( $suggestions ): array
 }
 
 /**
+ * Sanitize generic chat context forwarded with widget messages.
+ *
+ * This is intentionally an opaque key/value payload. Integrations may use it
+ * to provide a selected brain, corpus, or source-scope hint while Agents API
+ * and domain plugins own the concrete semantics and authorization checks.
+ *
+ * @param mixed $context Raw context configuration.
+ * @return array<string,mixed> Sanitized context.
+ */
+function frontend_agent_chat_sanitize_chat_context( $context ): array {
+	if ( ! is_array( $context ) ) {
+		return array();
+	}
+
+	$sanitized = array();
+	foreach ( $context as $key => $value ) {
+		$key = sanitize_key( (string) $key );
+		if ( '' === $key ) {
+			continue;
+		}
+
+		if ( is_bool( $value ) || is_int( $value ) || is_float( $value ) ) {
+			$sanitized[ $key ] = $value;
+			continue;
+		}
+
+		if ( is_string( $value ) ) {
+			$sanitized[ $key ] = sanitize_text_field( $value );
+			continue;
+		}
+
+		if ( is_array( $value ) ) {
+			$items = array();
+			foreach ( $value as $item ) {
+				if ( is_scalar( $item ) ) {
+					$items[] = sanitize_text_field( (string) $item );
+				}
+			}
+			if ( ! empty( $items ) ) {
+				$sanitized[ $key ] = $items;
+			}
+		}
+	}
+
+	return $sanitized;
+}
+
+/**
  * Enqueue the frontend chat script and styles.
  *
  * Fires on wp_enqueue_scripts so the assets load on every frontend page.
@@ -190,6 +238,11 @@ function frontend_agent_chat_enqueue() {
 	$message_suggestions = frontend_agent_chat_sanitize_message_suggestions( $config['message_suggestions'] ?? array() );
 	if ( ! empty( $message_suggestions ) ) {
 		$js_config['messageSuggestions'] = $message_suggestions;
+	}
+
+	$chat_context = frontend_agent_chat_sanitize_chat_context( $config['chat_context'] ?? $config['context'] ?? array() );
+	if ( ! empty( $chat_context ) ) {
+		$js_config['chatContext'] = $chat_context;
 	}
 
 	wp_localize_script(

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -91,6 +91,7 @@ interface AgentChatProps {
 		actionUrl?: string;
 	};
 	messageSuggestions?: ChatMessageSuggestion[];
+	chatContext?: Record< string, unknown >;
 	capabilities?: {
 		chat_run_status?: boolean;
 		chat_run_cancel?: boolean;
@@ -768,6 +769,7 @@ export default function AgentChat( {
 	loadingMessages = true,
 	persistenceCta,
 	messageSuggestions,
+	chatContext,
 	capabilities,
 	operatorDiagnosticsEnabled,
 }: AgentChatProps ) {
@@ -820,6 +822,13 @@ export default function AgentChat( {
 				capabilities
 			),
 		[ agentFetch, basePath, capabilities ]
+	);
+	const messageMetadata = useMemo(
+		() =>
+			chatContext && Object.keys( chatContext ).length > 0
+				? { chat_context: chatContext }
+				: undefined,
+		[ chatContext ]
 	);
 	const open = useCallback( () => setIsOpen( true ), [] );
 	const close = useCallback( () => {
@@ -985,6 +994,7 @@ export default function AgentChat( {
 	useEffect( () => {
 		setUnreadCount( 0 );
 		setRetrievalState( null );
+		setOperatorDiagnosticsMetadata( null );
 	}, [ activeAgentSlug ] );
 
 	// Escape exits expanded mode first, then closes the drawer.
@@ -1218,6 +1228,7 @@ export default function AgentChat( {
 						),
 						clientContext: true,
 						clientContextOptions: { metadataKey: 'client_context' },
+						metadata: messageMetadata,
 						onMessage: handleMessage,
 						onError: handleError,
 						onResponseMetadata: handleResponseMetadata,

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -377,7 +377,10 @@
 }
 
 .frontend-agent-chat__retrieval-state.is-partial,
-.frontend-agent-chat__retrieval-state.is-no-answer {
+.frontend-agent-chat__retrieval-state.is-no-answer,
+.frontend-agent-chat__retrieval-state.is-permission-denied,
+.frontend-agent-chat__retrieval-state.is-source-restricted,
+.frontend-agent-chat__retrieval-state.is-stale {
 	border-color: var(--frontend-agent-chat-warning-border, #fde68a);
 	background: var(--frontend-agent-chat-warning-bg, #fef3c7);
 }
@@ -397,6 +400,71 @@
 	color: var(--frontend-agent-chat-text-muted, #475569);
 	font-size: 12px;
 	line-height: 1.4;
+}
+
+.frontend-agent-chat__body .ec-chat-citations {
+	margin-top: 10px;
+	padding-top: 10px;
+	border-top: 1px solid var(--frontend-agent-chat-border-color, #e2e8f0);
+}
+
+.frontend-agent-chat__body .ec-chat-citations__label {
+	margin-bottom: 6px;
+	color: var(--frontend-agent-chat-text-muted, #64748b);
+	font-size: 12px;
+	font-weight: 700;
+	line-height: 1.35;
+}
+
+.frontend-agent-chat__body .ec-chat-citations__list {
+	display: grid;
+	gap: 6px;
+	margin: 0;
+	padding-left: 0;
+	list-style: none;
+}
+
+.frontend-agent-chat__body .ec-chat-citation {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	gap: 4px 6px;
+	padding: 8px 10px;
+	border: 1px solid var(--frontend-agent-chat-border-color, #e2e8f0);
+	border-radius: 10px;
+	background: var(--frontend-agent-chat-bg-muted, #f8fafc);
+	color: var(--frontend-agent-chat-text-primary, #1e293b);
+	font-size: 12px;
+	line-height: 1.35;
+	text-decoration: none;
+}
+
+.frontend-agent-chat__body a.ec-chat-citation:hover {
+	border-color: var(--frontend-agent-chat-accent-border, #bfdbfe);
+	color: var(--frontend-agent-chat-accent, #2563eb);
+}
+
+.frontend-agent-chat__body .ec-chat-citation__index {
+	min-width: 18px;
+	height: 18px;
+	border-radius: 999px;
+	background: var(--frontend-agent-chat-muted-bg, #e2e8f0);
+	color: var(--frontend-agent-chat-text-muted, #475569);
+	font-size: 11px;
+	font-weight: 700;
+	line-height: 18px;
+	text-align: center;
+}
+
+.frontend-agent-chat__body .ec-chat-citation__label {
+	min-width: 0;
+	font-weight: 700;
+	overflow-wrap: anywhere;
+}
+
+.frontend-agent-chat__body .ec-chat-citation__snippet {
+	grid-column: 1 / -1;
+	color: var(--frontend-agent-chat-text-muted, #64748b);
+	overflow-wrap: anywhere;
 }
 
 .frontend-agent-chat__tool-card {

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ declare global {
 				actionUrl?: string;
 			};
 			messageSuggestions?: ChatMessageSuggestion[];
+			chatContext?: Record< string, unknown >;
 			capabilities?: {
 				chat_run_status?: boolean;
 				chat_run_cancel?: boolean;
@@ -112,6 +113,7 @@ function init(): void {
 			loadingMessages: config.loadingMessages ?? true,
 			persistenceCta: config.persistenceCta,
 			messageSuggestions: config.messageSuggestions,
+			chatContext: config.chatContext,
 			capabilities: config.capabilities,
 			operatorDiagnosticsEnabled: config.operatorDiagnosticsEnabled,
 		} )

--- a/src/operator-diagnostics.ts
+++ b/src/operator-diagnostics.ts
@@ -9,6 +9,10 @@ export interface OperatorDiagnosticsPanel {
 }
 
 const DIAGNOSTICS_KEYS = [
+	'source_diagnostics',
+	'sourceDiagnostics',
+	'retrieval_diagnostics',
+	'retrievalDiagnostics',
 	'operator_diagnostics',
 	'operatorDiagnostics',
 	'diagnostics',
@@ -115,7 +119,7 @@ export function getOperatorDiagnosticsPanel( metadata: Record< string, unknown >
 
 	const title = stringifyValue( source.title ?? source.label );
 	return {
-		title: title || 'Operator diagnostics',
+		title: title || 'Source diagnostics',
 		rows,
 	};
 }

--- a/src/retrieval-state.test.ts
+++ b/src/retrieval-state.test.ts
@@ -73,6 +73,41 @@ describe( 'getRetrievalState', () => {
 		} );
 	} );
 
+	it( 'renders source restriction diagnostics from generic metadata', () => {
+		expect(
+			getRetrievalState( {
+				source_diagnostics: {
+					status: 'source restricted',
+				},
+				citation_count: 2,
+			} )
+		).toEqual( {
+			kind: 'source_restricted',
+			label: 'Source access was restricted',
+			description:
+				'The answer may exclude sources that are restricted for this chat.',
+			sourceCount: 2,
+		} );
+	} );
+
+	it( 'renders stale-source diagnostics from generic metadata', () => {
+		expect(
+			getRetrievalState( {
+				retrieval: {
+					diagnostic: 'stale sources',
+				},
+			} )?.kind
+		).toBe( 'stale' );
+	} );
+
+	it( 'renders permission diagnostics without source-specific labels', () => {
+		expect(
+			getRetrievalState( {
+				permissionDenied: true,
+			} )?.label
+		).toBe( 'Some sources need permission' );
+	} );
+
 	it( 'infers grounded state from source count metadata', () => {
 		expect(
 			getRetrievalState( {

--- a/src/retrieval-state.ts
+++ b/src/retrieval-state.ts
@@ -1,4 +1,11 @@
-export type RetrievalStateKind = 'grounded' | 'partial' | 'no_answer' | 'error';
+export type RetrievalStateKind =
+	| 'grounded'
+	| 'partial'
+	| 'no_answer'
+	| 'permission_denied'
+	| 'source_restricted'
+	| 'stale'
+	| 'error';
 
 export interface RetrievalState {
 	kind: RetrievalStateKind;
@@ -13,9 +20,25 @@ const STATUS_ALIASES: Record< string, RetrievalStateKind > = {
 	available: 'grounded',
 	retrieved: 'grounded',
 	partial: 'partial',
+	partial_result: 'partial',
+	partial_results: 'partial',
+	partial_sources: 'partial',
 	limited: 'partial',
 	insufficient: 'partial',
 	weak: 'partial',
+	permission_denied: 'permission_denied',
+	access_denied: 'permission_denied',
+	forbidden: 'permission_denied',
+	not_authorized: 'permission_denied',
+	source_restricted: 'source_restricted',
+	restricted: 'source_restricted',
+	restricted_source: 'source_restricted',
+	restricted_sources: 'source_restricted',
+	sources_restricted: 'source_restricted',
+	stale: 'stale',
+	stale_source: 'stale',
+	stale_sources: 'stale',
+	stale_context: 'stale',
 	no_answer: 'no_answer',
 	no_answer_found: 'no_answer',
 	no_relevant_source: 'no_answer',
@@ -39,10 +62,17 @@ const STATUS_PATHS = [
 	[ 'retrievedContextStatus' ],
 	[ 'retrieval', 'status' ],
 	[ 'retrieval', 'state' ],
+	[ 'retrieval', 'diagnostic' ],
 	[ 'retrieved_context', 'status' ],
 	[ 'retrievedContext', 'status' ],
 	[ 'grounding', 'status' ],
 	[ 'grounding', 'state' ],
+	[ 'source_diagnostics', 'status' ],
+	[ 'sourceDiagnostics', 'status' ],
+	[ 'source_diagnostics', 'kind' ],
+	[ 'sourceDiagnostics', 'kind' ],
+	[ 'diagnostics', 'retrieval_status' ],
+	[ 'diagnostics', 'retrievalStatus' ],
 ];
 
 const SOURCE_COUNT_PATHS = [
@@ -111,6 +141,33 @@ function createRetrievalState( kind: RetrievalStateKind, sourceCount?: number ):
 		};
 	}
 
+	if ( kind === 'permission_denied' ) {
+		return {
+			kind,
+			label: 'Some sources need permission',
+			description: 'The agent could not use one or more sources for this request.',
+			sourceCount,
+		};
+	}
+
+	if ( kind === 'source_restricted' ) {
+		return {
+			kind,
+			label: 'Source access was restricted',
+			description: 'The answer may exclude sources that are restricted for this chat.',
+			sourceCount,
+		};
+	}
+
+	if ( kind === 'stale' ) {
+		return {
+			kind,
+			label: 'Sources may be stale',
+			description: 'Retrieved context was available, but some source freshness warnings were reported.',
+			sourceCount,
+		};
+	}
+
 	return {
 		kind,
 		label: 'Retrieval unavailable',
@@ -142,6 +199,18 @@ function inferStatus( metadata: Record< string, unknown >, sourceCount: number |
 
 	if ( readBoolean( metadata, [ 'partial_evidence', 'partialEvidence', 'partial_context', 'partialContext' ] ) ) {
 		return 'partial';
+	}
+
+	if ( readBoolean( metadata, [ 'permission_denied', 'permissionDenied', 'access_denied', 'accessDenied' ] ) ) {
+		return 'permission_denied';
+	}
+
+	if ( readBoolean( metadata, [ 'source_restricted', 'sourceRestricted', 'sources_restricted', 'sourcesRestricted' ] ) ) {
+		return 'source_restricted';
+	}
+
+	if ( readBoolean( metadata, [ 'stale_source', 'staleSource', 'stale_sources', 'staleSources' ] ) ) {
+		return 'stale';
 	}
 
 	if ( sourceCount !== undefined ) {

--- a/tests/chat-context-config-smoke.php
+++ b/tests/chat-context-config-smoke.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Smoke tests for generic chat context config sanitation.
+ *
+ * @package FrontendAgentChat\Tests
+ */
+
+function frontend_agent_chat_context_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $key ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ) {
+		return trim( wp_strip_all_tags( (string) $value ) );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $value ) {
+		return strip_tags( (string) $value );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text ) {
+		return $text;
+	}
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/enqueue.php';
+
+$context = frontend_agent_chat_sanitize_chat_context(
+	array(
+		'brain_slug'       => 'core-private',
+		'source_scope'     => 'wiki <strong>private</strong>',
+		'source_ids'       => array( 'wiki', 'memory', array( 'skip' ) ),
+		'include_private'  => true,
+		'empty_value'      => '',
+		'unsupported_json' => array( array( 'nested' => 'skip' ) ),
+	)
+);
+
+frontend_agent_chat_context_assert( 'core-private' === ( $context['brain_slug'] ?? '' ), 'Brain slug context is preserved.' );
+frontend_agent_chat_context_assert( 'wiki private' === ( $context['source_scope'] ?? '' ), 'String context values are sanitized.' );
+frontend_agent_chat_context_assert( array( 'wiki', 'memory' ) === ( $context['source_ids'] ?? array() ), 'Scalar context arrays are preserved.' );
+frontend_agent_chat_context_assert( true === ( $context['include_private'] ?? false ), 'Boolean context values are preserved.' );
+frontend_agent_chat_context_assert( array_key_exists( 'unsupported_json', $context ) === false, 'Nested unsupported context is omitted.' );
+
+echo "Frontend chat-context config smoke passed (5 assertions).\n";

--- a/tests/chat-context-config-smoke.php
+++ b/tests/chat-context-config-smoke.php
@@ -49,19 +49,19 @@ require_once __DIR__ . '/../inc/enqueue.php';
 
 $context = frontend_agent_chat_sanitize_chat_context(
 	array(
-		'brain_slug'       => 'core-private',
-		'source_scope'     => 'wiki <strong>private</strong>',
+		'brain_slug'       => 'core-brain',
+		'source_scope'     => 'wiki <strong>corpus</strong>',
 		'source_ids'       => array( 'wiki', 'memory', array( 'skip' ) ),
-		'include_private'  => true,
+		'include_restricted_sources' => true,
 		'empty_value'      => '',
 		'unsupported_json' => array( array( 'nested' => 'skip' ) ),
 	)
 );
 
-frontend_agent_chat_context_assert( 'core-private' === ( $context['brain_slug'] ?? '' ), 'Brain slug context is preserved.' );
-frontend_agent_chat_context_assert( 'wiki private' === ( $context['source_scope'] ?? '' ), 'String context values are sanitized.' );
+frontend_agent_chat_context_assert( 'core-brain' === ( $context['brain_slug'] ?? '' ), 'Brain slug context is preserved.' );
+frontend_agent_chat_context_assert( 'wiki corpus' === ( $context['source_scope'] ?? '' ), 'String context values are sanitized.' );
 frontend_agent_chat_context_assert( array( 'wiki', 'memory' ) === ( $context['source_ids'] ?? array() ), 'Scalar context arrays are preserved.' );
-frontend_agent_chat_context_assert( true === ( $context['include_private'] ?? false ), 'Boolean context values are preserved.' );
+frontend_agent_chat_context_assert( true === ( $context['include_restricted_sources'] ?? false ), 'Boolean context values are preserved.' );
 frontend_agent_chat_context_assert( array_key_exists( 'unsupported_json', $context ) === false, 'Nested unsupported context is omitted.' );
 
 echo "Frontend chat-context config smoke passed (5 assertions).\n";

--- a/tests/operator-diagnostics-smoke.ts
+++ b/tests/operator-diagnostics-smoke.ts
@@ -6,11 +6,12 @@ import {
 } from '../src/operator-diagnostics.ts';
 
 const metadata = {
-	operator_diagnostics: {
+	source_diagnostics: {
 		title: 'Retrieval diagnostics',
 		rows: [
 			{ label: 'Mode', value: 'semantic' },
 			{ label: 'Result count', value: 3 },
+			{ label: 'Restricted sources', value: 1 },
 			{ label: 'Provider errors', value: [ 'timeout' ] },
 		],
 	},
@@ -36,7 +37,7 @@ assert.equal(
 
 assert.deepEqual(
 	getOperatorDiagnosticsRows( metadata ).map( ( row ) => row.label ),
-	[ 'Mode', 'Result count', 'Provider errors' ],
+	[ 'Mode', 'Result count', 'Restricted sources', 'Provider errors' ],
 	'operator diagnostics rows are supplied by metadata rather than a built-in domain field map'
 );
 


### PR DESCRIPTION
## Summary
- Adds an explicit generic `chat_context` config slot that is sanitized and forwarded as message metadata so existing Intelligence product surfaces and future VIP installs can supply selected brain/corpus/source-scope hints without frontend-agent-chat owning domain semantics.
- Expands generic retrieval/source diagnostics handling for partial, permission-denied, restricted-source, and stale-source states.
- Styles the existing `@extrachill/chat` citation list so normalized assistant citations render as clickable, readable source cards in the widget.

## Product framing
- This supports generic brain-aware chat surfaces, including the existing Intelligence dogfood product surfaces and future VIP/customer installs.
- The generic widget does not encode Horse styling, A8C source labels, or custom privacy mechanics.
- Privacy/access remains owned by backend WordPress-native permission/principal contracts and runtime/proxy controls.

## Dependencies / placeholders
- Keeps concrete principal/client-context authorization semantics in Automattic/agents-api#313.
- Keeps permission-aware retrieval/provenance semantics in Automattic/intelligence#815.
- Can consume richer scorecard/freshness metadata from Automattic/intelligence#816 through the same generic diagnostics paths.

Closes #79.

## Verification
- `npm run typecheck`
- `npm run test:unit`
- `npm run test:diagnostics`
- `php tests/source-cards-message-metadata-smoke.php`
- `php tests/chat-context-config-smoke.php`
- `npm run build`
- `git diff --check`

Latest framing-only verification:
- `php tests/chat-context-config-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic chat metadata, diagnostics, citation styling, framing cleanup, and targeted verification for Chris to review.