### PR TITLE
feat: emit action-resolved event on pending-action resolve

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -197,10 +197,15 @@ interface ActionResolvedDetail {
 }
 
 /**
- * Pull a scalar value (string or number) for `key` from anywhere it commonly
- * appears in a resolve response: the top-level data object, or its nested
- * `result` payload. Resolve responses are shaped by the concrete handler, so
- * this stays defensive rather than assuming one layout.
+ * Pull a scalar value (string or number) for `key` from a resolve response.
+ *
+ * The resolve response is wrapped in NESTED `result` envelopes: the agents-api
+ * resolver returns `{ action_id, decision, result }`, whose `result` is itself
+ * `{ success, kind, result }`, whose innermost `result` is the concrete apply
+ * handler's output (where `post_id` actually lives). The exact depth and shape
+ * are owned by the concrete handler, not this plugin, so we walk each object +
+ * its chain of `result` children to whatever depth the field appears at. This
+ * stays defensive rather than assuming one fixed layout.
  *
  * @param data Parsed resolve response `data` object.
  * @param key  Field name to extract.
@@ -210,20 +215,22 @@ function readResolvedScalar(
 	data: Record< string, unknown > | undefined,
 	key: string
 ): number | string | undefined {
-	if ( ! data || typeof data !== 'object' ) {
-		return undefined;
-	}
+	// Bounded depth so a self-referential payload cannot loop forever.
+	const MAX_DEPTH = 6;
+	let node: unknown = data;
 
-	const candidates: unknown[] = [ data[ key ] ];
-	const result = data.result;
-	if ( result && typeof result === 'object' ) {
-		candidates.push( ( result as Record< string, unknown > )[ key ] );
-	}
+	for ( let depth = 0; depth < MAX_DEPTH; depth++ ) {
+		if ( ! node || typeof node !== 'object' ) {
+			return undefined;
+		}
 
-	for ( const candidate of candidates ) {
+		const candidate = ( node as Record< string, unknown > )[ key ];
 		if ( typeof candidate === 'number' || typeof candidate === 'string' ) {
 			return candidate;
 		}
+
+		// Descend into the nested result envelope, if present.
+		node = ( node as Record< string, unknown > ).result;
 	}
 
 	return undefined;

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -181,11 +181,81 @@ const DEFAULT_EXPAND_ICON_PATH = 'M3 8V3h5M21 8V3h-5M3 16v5h5M21 16v5h-5';
 const DEFAULT_COLLAPSE_ICON_PATH = 'M8 3v5H3M16 3v5h5M8 21v-5H3M16 21v-5h5';
 
 /**
+ * `detail` payload of the `frontend-agent-chat:action-resolved` event.
+ *
+ * Carries the resolved action id + decision, plus whatever resource identity
+ * the resolve response exposed (`post_id`, `blog_id`, `kind`). The plugin makes
+ * no assumptions about who consumes this; it only announces that a pending
+ * action resolved on the DOM.
+ */
+interface ActionResolvedDetail {
+	action_id: string;
+	decision: 'accepted' | 'rejected';
+	post_id?: number | string;
+	blog_id?: number | string;
+	kind?: string;
+}
+
+/**
+ * Pull a scalar value (string or number) for `key` from anywhere it commonly
+ * appears in a resolve response: the top-level data object, or its nested
+ * `result` payload. Resolve responses are shaped by the concrete handler, so
+ * this stays defensive rather than assuming one layout.
+ *
+ * @param data Parsed resolve response `data` object.
+ * @param key  Field name to extract.
+ * @return The first scalar value found, or undefined.
+ */
+function readResolvedScalar(
+	data: Record< string, unknown > | undefined,
+	key: string
+): number | string | undefined {
+	if ( ! data || typeof data !== 'object' ) {
+		return undefined;
+	}
+
+	const candidates: unknown[] = [ data[ key ] ];
+	const result = data.result;
+	if ( result && typeof result === 'object' ) {
+		candidates.push( ( result as Record< string, unknown > )[ key ] );
+	}
+
+	for ( const candidate of candidates ) {
+		if ( typeof candidate === 'number' || typeof candidate === 'string' ) {
+			return candidate;
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Announce that a pending action resolved by dispatching a generic `window`
+ * CustomEvent. The plugin does not know who listens — a host adapter may
+ * translate this into its own editor-refresh signal.
+ *
+ * @param detail Resolved action detail.
+ */
+function dispatchActionResolved( detail: ActionResolvedDetail ): void {
+	window.dispatchEvent(
+		new CustomEvent( 'frontend-agent-chat:action-resolved', {
+			detail,
+		} )
+	);
+}
+
+/**
  * Resolve a pending action by id.
  *
  * The server route dispatches to the canonical `agents/resolve-pending-action`
  * ability so tool preview resolution stays independent from the concrete
  * runtime/store implementation.
+ *
+ * On a SUCCESSFUL resolution, a generic `frontend-agent-chat:action-resolved`
+ * window event is dispatched carrying the action id, decision, and whatever
+ * resource identity the resolve response surfaced. The plugin only announces
+ * the resolution; it has no knowledge of any host editor that may refresh in
+ * response.
  *
  * @param actionId Pending action ID.
  * @param decision Resolution decision.
@@ -198,14 +268,48 @@ function resolvePendingAction(
 		path: '/frontend-agent-chat/v1/chat/actions/resolve',
 		method: 'POST',
 		data: { action_id: actionId, decision },
-	} ).catch( ( err: unknown ) => {
-		// eslint-disable-next-line no-console
-		console.error(
-			'AgentChat: failed to resolve pending action',
-			actionId,
-			err
-		);
-	} );
+	} )
+		.then( ( response: unknown ) => {
+			const data =
+				response && typeof response === 'object'
+					? ( ( response as { data?: unknown } ).data as
+							| Record< string, unknown >
+							| undefined )
+					: undefined;
+
+			// Only emit on a successful resolution. A failed resolve never
+			// changed the post, so there is nothing for a host to refresh.
+			if ( data && data.success === false ) {
+				return;
+			}
+
+			const detail: ActionResolvedDetail = {
+				action_id: actionId,
+				decision,
+			};
+			const postId = readResolvedScalar( data, 'post_id' );
+			const blogId = readResolvedScalar( data, 'blog_id' );
+			const kind = readResolvedScalar( data, 'kind' );
+			if ( postId !== undefined ) {
+				detail.post_id = postId;
+			}
+			if ( blogId !== undefined ) {
+				detail.blog_id = blogId;
+			}
+			if ( typeof kind === 'string' ) {
+				detail.kind = kind;
+			}
+
+			dispatchActionResolved( detail );
+		} )
+		.catch( ( err: unknown ) => {
+			// eslint-disable-next-line no-console
+			console.error(
+				'AgentChat: failed to resolve pending action',
+				actionId,
+				err
+			);
+		} );
 }
 
 /**


### PR DESCRIPTION
## Summary

When a chat-proposed block edit (`edit_post_blocks` / `replace_post_blocks` / `insert_content` with `preview=true`) is accepted in the DiffCard, the corrected content is written to the post server-side — but the accept path dispatched **no** success event, so any host editor open on the same post never learns its content changed and clobbers the accepted edit on its next autosave.

This adds a generic `window` CustomEvent on pending-action resolution so host editors can react. The plugin only announces the resolution on the DOM; it knows nothing about who listens.

Closes #84.

## What changed

`src/AgentChat.tsx` — `resolvePendingAction()` now reads the resolve response and, on success, dispatches:

```
window.dispatchEvent( new CustomEvent( 'frontend-agent-chat:action-resolved', {
    detail: { action_id, decision, post_id?, blog_id?, kind? },
} ) );
```

- Mirrors the existing `frontend-agent-chat:response-metadata` / `:lifecycle` / `:run-event` dispatch helpers (added a `dispatchActionResolved` sibling).
- `post_id` / `blog_id` / `kind` are pulled from the resolve response via a defensive `readResolvedScalar()` that checks both the top-level `data` and its nested `result` payload (the resolve response is shaped by the concrete handler, so identity may live in either place). Fields are omitted from `detail` when the response doesn't surface them.

## Accept vs. reject

**Both decisions dispatch** (carrying `decision: 'accepted' | 'rejected'`). This is the simpler, single-code-path behavior; a failed resolve (`data.success === false`) dispatches nothing, since the post never changed. Consumers filter on `decision` themselves.

## Layer purity

ZERO host/vendor strings in the `src/` diff:

```
$ git diff --cached -- src/ | grep '^+' | grep -iE 'studio|roadie|blocks-everywhere|extrachill'
CLEAN src/: zero host/vendor strings
```

The only `frontend-agent-chat:*` string is the plugin's own event namespace, matching the existing CustomEvents in this file. The consumer (Extra-Chill/blocks-everywhere#107 receiver) and the thin host adapter (Extra-Chill/extrachill-studio#101) live elsewhere; FAC does not reference them.

## Verification

- `npm run typecheck` clean.
- `npm run build` compiles successfully.
- `wp-scripts lint-js` clean.

## Merge order

Merge this **and** Extra-Chill/blocks-everywhere#108 (the generic receiver) before the Studio adapter (Extra-Chill/extrachill-studio#101), which bridges this event into BE's refresh event.