### PR TITLE
Use chat package without question freeform input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "^0.14.0",
+				"@extrachill/chat": "github:Extra-Chill/chat#fbb600d28b82c05ac75135955c9f1f6cadc25f07",
 				"@wordpress/element": "^6.46.0",
 				"@wordpress/i18n": "^6.21.0"
 			},
@@ -2659,8 +2659,8 @@
 		},
 		"node_modules/@extrachill/chat": {
 			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.14.0.tgz",
-			"integrity": "sha512-reP65ZD0vR3RwJmqQqu9NzG235033tgkEKpFCw8ZdpqEI8Z/8iVE2NV1xfm4YMmDjo25WH0fA9y3r9cSPsUDyQ==",
+			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#fbb600d28b82c05ac75135955c9f1f6cadc25f07",
+			"integrity": "sha512-L9l8r/MkgCjC+t4TVlFasg/BLvXfWFUR3PEwxQ63pvcsxPoZJ/KHYoTUphH+NC3RliBCmNRJP8Y0Bah6OE6PWg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "^0.14.0",
+		"@extrachill/chat": "github:Extra-Chill/chat#fbb600d28b82c05ac75135955c9f1f6cadc25f07",
 		"@wordpress/element": "^6.46.0",
 		"@wordpress/i18n": "^6.21.0"
 	},


### PR DESCRIPTION
## Summary
- Consume the merged @extrachill/chat fix that removes question-card freeform inputs entirely.
- Keeps typed answers in the outer chat composer instead of rendering a second message box inside question cards.

## Upstream
- Extra-Chill/chat#56

## Testing
- npm run build
- npm run typecheck
- npm run test:diagnostics

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated the package dependency to the merged upstream fix and ran frontend build/typecheck/smoke verification.