### PR TITLE
Use published chat package release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat#fbb600d28b82c05ac75135955c9f1f6cadc25f07",
+				"@extrachill/chat": "^0.14.1",
 				"@wordpress/element": "^6.46.0",
 				"@wordpress/i18n": "^6.21.0"
 			},
@@ -2658,9 +2658,9 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.14.0",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#fbb600d28b82c05ac75135955c9f1f6cadc25f07",
-			"integrity": "sha512-L9l8r/MkgCjC+t4TVlFasg/BLvXfWFUR3PEwxQ63pvcsxPoZJ/KHYoTUphH+NC3RliBCmNRJP8Y0Bah6OE6PWg==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.14.1.tgz",
+			"integrity": "sha512-K27M07nRY0OMwYdFYVZZ+JlqGDO+vU2Qo3rsavx/NLc+CV0LuDowi7UbtjGlH6UEkW7j6D1xHsNlfOwBtVM8nQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat#fbb600d28b82c05ac75135955c9f1f6cadc25f07",
+		"@extrachill/chat": "^0.14.1",
 		"@wordpress/element": "^6.46.0",
 		"@wordpress/i18n": "^6.21.0"
 	},


### PR DESCRIPTION
## Summary
- Switch @extrachill/chat from the temporary Git SHA dependency to the published npm release `^0.14.1`.
- Keeps the question-card freeform input removal while restoring normal npm registry resolution.

## Testing
- npm run build
- npm run typecheck
- npm run test:diagnostics

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated dependency metadata, verified the installed package no longer contains freeform question UI, and ran build/typecheck/smoke checks.
