### PR TITLE
fix: bump @extrachill/chat to 0.14.2 for answerable present_question cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "^0.14.1",
+				"@extrachill/chat": "^0.14.2",
 				"@wordpress/element": "^6.46.0",
 				"@wordpress/i18n": "^6.21.0"
 			},
@@ -2658,9 +2658,9 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.14.1.tgz",
-			"integrity": "sha512-K27M07nRY0OMwYdFYVZZ+JlqGDO+vU2Qo3rsavx/NLc+CV0LuDowi7UbtjGlH6UEkW7j6D1xHsNlfOwBtVM8nQ==",
+			"version": "0.14.2",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.14.2.tgz",
+			"integrity": "sha512-GJ2+D9FsmRNHcUvovrn5G9gl6xrXlJyxAYSUneC1YcRbxWJUB3iJXV0xwv9qWniR4P4AjF9FitFEPukooh50bw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "^0.14.1",
+		"@extrachill/chat": "^0.14.2",
 		"@wordpress/element": "^6.46.0",
 		"@wordpress/i18n": "^6.21.0"
 	},


### PR DESCRIPTION
## Summary

Bumps the `@extrachill/chat` dependency from `^0.14.1` to `^0.14.2` to pick up [Extra-Chill/chat#58](https://github.com/Extra-Chill/chat/pull/58).

That fix stops a `present_question` choice card from becoming unanswerable: the choice buttons were defaulting their `disabled` state to `context.isLoading`, so a turn that ended on an unanswered question (the observed Roadie pattern) left `isLoading` stuck `true` and the buttons permanently un-clickable. 0.14.2 makes a pending question always interactive.

## Changes
- `package.json`: `@extrachill/chat` `^0.14.1` → `^0.14.2`
- `package-lock.json`: resolves `@extrachill/chat@0.14.2` from npm

## Verification
- `npm run typecheck` (tsc --noEmit) — clean
- `npm run build` (wp-scripts) — succeeds; the rebuilt `build/index.js` now ships the fixed renderer (`e.disabled ?? false` instead of the old `e.disabled ?? n.isLoading`)
- `npm run test:unit` — 9/9 pass