### PR TITLE
feat: render question cards by result shape, not tool name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "^0.14.2",
+				"@extrachill/chat": "^0.15.0",
 				"@wordpress/element": "^6.46.0",
 				"@wordpress/i18n": "^6.21.0"
 			},
@@ -2658,9 +2658,9 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.14.2.tgz",
-			"integrity": "sha512-GJ2+D9FsmRNHcUvovrn5G9gl6xrXlJyxAYSUneC1YcRbxWJUB3iJXV0xwv9qWniR4P4AjF9FitFEPukooh50bw==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.15.0.tgz",
+			"integrity": "sha512-AOnhfE/X8NsFq4fr641CUW2XLblNUg35lvqBjXiPFb3TtxpfR9iRPY2+zONFUzC6QXN4rMxM0SzcchResL6+hw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "^0.14.2",
+		"@extrachill/chat": "^0.15.0",
 		"@wordpress/element": "^6.46.0",
 		"@wordpress/i18n": "^6.21.0"
 	},

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -36,6 +36,7 @@ import type {
 	FetchFn,
 	MediaUploadFn,
 	QueueMessageResult,
+	ShapeRenderer,
 } from '@extrachill/chat';
 import type { ChangeEvent, ReactNode } from 'react';
 
@@ -1148,9 +1149,24 @@ export default function AgentChat( {
 			edit_post_blocks: diffRenderer,
 			replace_post_blocks: diffRenderer,
 			insert_content: diffRenderer,
+			// Kept name-keyed for back-compat with the explicit
+			// `present_question` tool. Any *other* tool that returns a
+			// `{question, choices}` payload is handled by `shapeRenderers`
+			// below — no tool name is hardcoded for that generic path.
 			present_question: questionRenderer,
 		};
 	}, [] );
+
+	// Shape-based renderers dispatch off the *shape* of a tool result rather
+	// than its tool name. `createQuestionToolRenderer` returns `null` when a
+	// group has no `{question, choices}` payload, so any tool that carries that
+	// shape — present_question, file_feature_request, or any future
+	// candidate-producing tool — renders a QuestionCard with zero hardcoded
+	// tool names in this generic shell (extrachill-roadie#61).
+	const shapeRenderers = useMemo< ShapeRenderer[] >(
+		() => [ createQuestionToolRenderer() ],
+		[]
+	);
 	const renderChatHeader = useCallback( () => {
 		const retrievalStateNode = renderRetrievalState( retrievalState );
 		const operatorDiagnosticsNode = canShowOperatorDiagnostics
@@ -1332,6 +1348,7 @@ export default function AgentChat( {
 						showTools: true,
 						showSessions: true,
 						toolRenderers,
+						shapeRenderers,
 						placeholder: sprintf(
 							/* translators: %s: agent name. */
 							__( 'Ask %s anything…', 'frontend-agent-chat' ),


### PR DESCRIPTION
## Summary

Consume the new `@extrachill/chat` **shape-renderer** API so question/choice cards render off the **shape** of a tool result (`{question, choices}`) rather than off an exact tool name. Today a `QuestionCard` only renders when the tool is literally named `present_question`; after this, *any* tool that returns a `{question, choices}` payload (e.g. `file_feature_request` repo-disambiguation, or any future candidate-producing tool) renders the same card — with **zero hardcoded downstream tool names** in this generic shell.

This is the consumer side of **Extra-Chill/extrachill-roadie#61** — *multiple-choice is the default ask-shape; the chat box stays the universal escape hatch.*

## What changed

- `src/AgentChat.tsx`: register `createQuestionToolRenderer()` via the new `shapeRenderers` prop on `<Chat>`. `ChatMessages` tries shape renderers when no tool-name renderer matches; the question renderer returns `null` on a non-question shape, opting out cleanly and falling through to the default `ToolMessage`.
- The `present_question` name-keyed entry is **kept** for back-compat. The new generic path is **name-agnostic** — adding a new candidate-producing tool gets choice rendering for free (no code change in this shell), satisfying the RULES.md layer-purity test.
- `package.json`: bump `@extrachill/chat` `^0.14.0` → `^0.14.2` (the version exposing `ShapeRenderer` + the `shapeRenderers` prop on `ChatMessages` **and** the top-level `<Chat>`).

## Why

extrachill-roadie#61 — the choice-vs-prose decision should be driven by handler data (result shape), not re-decided by the model each turn or gated on one hardcoded tool name.

## Dependency / sequencing (merge order)

**This PR must merge AFTER:**
1. **Extra-Chill/chat#59** (`choice-shape-dispatch`) — adds `ShapeRenderer`, the `shapeRenderers` prop on `ChatMessages`, AND forwards it through the top-level `<Chat>` component (the latter was a gap in the originally-committed branch; fixed in that PR so consumers using `<Chat>` — like this one — can register shape renderers without reaching into `ChatMessages` directly).
2. A **`@extrachill/chat` release of `0.14.2`** publishing that API.

Required `@extrachill/chat` version: **`^0.14.2`**. Until 0.14.2 is published, `npm install` won't resolve it from the registry; this PR was verified by overlaying the locally-built chat `choice-shape-dispatch` branch into `node_modules`. Opened as **draft** until the chat release lands.

## Verification

- `npm run typecheck` — passes (against the new chat API).
- `npm run build` — succeeds, rebuilds `build/index.js` (gitignored).
- `npm run test:unit` — 9/9 pass.
- The chat package's own tests cover the end-to-end behavior this consumes: *"shape renderer renders a QuestionCard for a tool NOT named present_question"*, *"...skipped (falls through to ToolMessage) when there is no question shape"*, and *"tool-name renderers still take precedence over shape renderers"*.
- Confirmed `present_question` + diff (`edit_post_blocks`/`replace_post_blocks`/`insert_content`) + artifact-status rendering are untouched; freeform input stays default-on/non-blocking (the `QuestionCard` is a non-blocking affordance and the chat input is never disabled by it).

## Cross-references

- Extra-Chill/extrachill-roadie#61 — the architecture/epic (generic tool-result→choice contract).
- Extra-Chill/chat#59 — the chat-package shape-dispatch API this consumes (must merge + release first).
- Roadie structured-choices follow-up (the `file_feature_request` handler returning structured candidates) is the producer side that benefits from this name-agnostic rendering.