### PR TITLE
Bump @extrachill/chat to 0.15.1 (rich question choice presentations)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "^0.15.0",
+				"@extrachill/chat": "^0.15.1",
 				"@wordpress/element": "^6.46.0",
 				"@wordpress/i18n": "^6.21.0"
 			},
@@ -2658,9 +2658,9 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.15.0.tgz",
-			"integrity": "sha512-AOnhfE/X8NsFq4fr641CUW2XLblNUg35lvqBjXiPFb3TtxpfR9iRPY2+zONFUzC6QXN4rMxM0SzcchResL6+hw==",
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.15.1.tgz",
+			"integrity": "sha512-Gs9mZMIWGdyDMD6BckoH7+oew0N/c3AocOr8o2Ooke7d87x87bs2KIxfL8OIRNulHHV4kPz7OMrkVxSbFbpElQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "^0.15.0",
+		"@extrachill/chat": "^0.15.1",
 		"@wordpress/element": "^6.46.0",
 		"@wordpress/i18n": "^6.21.0"
 	},


### PR DESCRIPTION
## Summary
- Bump `@extrachill/chat` from `^0.15.0` to `^0.15.1` (lockfile now resolves `0.15.1`).
- Picks up [Extra-Chill/chat#61](https://github.com/Extra-Chill/chat/pull/61) — rich question choice presentations (color swatches, font samples, images, layout hints in question cards). FAC will not expose the new rendering until this dependency bump is built/released.

## Changes
- `package.json`: `@extrachill/chat` → `^0.15.1`
- `package-lock.json`: resolved to `chat-0.15.1.tgz`

## Testing
- `npm install` (lockfile updated to 0.15.1)
- `npm run build` — succeeds; bundles updated `@extrachill/chat/css/chat.css` (now includes new question-choice styles)
- `npm run typecheck` — clean (exit 0)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Extra Chill Bot)
- **Used for:** Released `@extrachill/chat@0.15.1` and bumped the FAC consumer dependency under Chris's direction.