### PR TITLE
Suppress rendered tool message text

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -1492,14 +1492,9 @@ export default function AgentChat( {
 						{ className: 'frontend-agent-chat__question-stack' },
 						...renderedTools
 					);
-				const textContent = message.content.filter(
-					( part ) => part.type === 'text' && part.text
-				);
-
 				return {
 					...message,
 					content: [
-						...textContent,
 						{
 							type: 'component' as const,
 							component: ToolComponent,


### PR DESCRIPTION
## Summary
- Render tool components without also preserving the raw tool-message text payload.
- Prevent structured question cards from appearing alongside raw JSON content.

## Testing
- npm run typecheck
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the raw tool text rendering path, editing the frontend display mapping, and running verification.