### PR TITLE
Fix chat session reset on message updates

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -1617,10 +1617,11 @@ export default function AgentChat( {
 			chat.sendMessage( message, canUploadFiles ? files : undefined ),
 		[ canUploadFiles, chat ]
 	);
+	const newChatSession = chat.newSession;
 	useEffect( () => {
-		chat.newSession();
+		newChatSession();
 		setUnreadCount( 0 );
-	}, [ activeAgentSlug, chat ] );
+	}, [ activeAgentSlug, newChatSession ] );
 	const hasPersistenceCta = !! (
 		persistenceCta?.message ||
 		( persistenceCta?.actionUrl && persistenceCta?.actionLabel )


### PR DESCRIPTION
## Summary
- Stop resetting the active chat session whenever chat state changes.
- Keep session reset scoped to selected-agent changes by depending on the stable new-session callback instead of the whole chat state object.

## Testing
- npm run typecheck
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Regression diagnosis, minimal React hook dependency fix, verification, and PR preparation.