### PR TITLE
Fix inline chat agent header

### DIFF
--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -1684,40 +1684,39 @@ export default function AgentChat( {
 			createElement(
 				'div',
 				{ className: 'frontend-agent-chat__header' },
-				! isInline &&
-					createElement(
-						'div',
-						{ className: 'frontend-agent-chat__agent' },
-						agents.length > 1
-							? createElement(
-									'select',
-									{
-										className:
-											'frontend-agent-chat__agent-select',
-										value: activeAgentSlug,
-										onChange: switchAgent,
-										'aria-label': __(
-											'Select chat agent',
-											'frontend-agent-chat'
-										),
-									},
-									agents.map( ( agent ) =>
-										createElement(
-											'option',
-											{
-												key: agent.slug,
-												value: agent.slug,
-											},
-											agent.name
-										)
+				createElement(
+					'div',
+					{ className: 'frontend-agent-chat__agent' },
+					agents.length > 1
+						? createElement(
+								'select',
+								{
+									className:
+										'frontend-agent-chat__agent-select',
+									value: activeAgentSlug,
+									onChange: switchAgent,
+									'aria-label': __(
+										'Select chat agent',
+										'frontend-agent-chat'
+									),
+								},
+								agents.map( ( agent ) =>
+									createElement(
+										'option',
+										{
+											key: agent.slug,
+											value: agent.slug,
+										},
+										agent.name
 									)
-							  )
-							: createElement(
-									'span',
-									{ className: 'frontend-agent-chat__title' },
-									activeAgentName
-							  )
-					),
+								)
+						  )
+						: createElement(
+								'span',
+								{ className: 'frontend-agent-chat__title' },
+								activeAgentName
+						  )
+				),
 				createElement(
 					'div',
 					{ className: 'frontend-agent-chat__header-actions' },


### PR DESCRIPTION
## Summary
- Render the agent title/select in inline chat layouts as well as floating layouts.
- Restores host integrations that depend on the shared chat header for product identity.

## Testing
- npm run typecheck
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the inline header regression and drafting the minimal code change.