### PR TITLE
Pin Agenttic trunk for inline chat fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
 			"name": "frontend-agent-chat",
 			"version": "0.1.0",
 			"dependencies": {
-				"@automattic/agenttic-client": "0.1.68",
-				"@automattic/agenttic-ui": "0.1.68",
+				"@automattic/agenttic-client": "file:../agenttic/packages/agenttic-client",
+				"@automattic/agenttic-ui": "file:../agenttic/packages/agenttic-ui",
 				"@wordpress/element": "^6.46.0",
 				"@wordpress/i18n": "^6.21.0"
 			},
@@ -17,6 +17,100 @@
 				"@types/wordpress__block-editor": "^15.0.5",
 				"@wordpress/scripts": "^31.1.0",
 				"typescript": "^5.7.0"
+			}
+		},
+		"../agenttic/packages/agenttic-client": {
+			"name": "@automattic/agenttic-client",
+			"version": "0.1.68",
+			"license": "MIT",
+			"dependencies": {
+				"@types/react": "^18.0.0",
+				"react": "^18.0.0"
+			},
+			"devDependencies": {
+				"@wordpress/api-fetch": "^7.0.0",
+				"autoprefixer": "^10.4.0",
+				"typescript": "^5.0.0",
+				"unified": "^11.0.5",
+				"vite": "^5.0.0",
+				"vite-plugin-lib-inject-css": "^2.2.2",
+				"vitest": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"marked": "^16.2.1"
+			},
+			"peerDependencies": {
+				"@wordpress/api-fetch": "^6.0.0 || ^7.0.0",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@wordpress/api-fetch": {
+					"optional": true
+				}
+			}
+		},
+		"../agenttic/packages/agenttic-ui": {
+			"name": "@automattic/agenttic-ui",
+			"version": "0.1.68",
+			"license": "MIT",
+			"dependencies": {
+				"@automattic/charts": ">=0.58.0 <1.0.0",
+				"@radix-ui/react-popover": "^1.1.15",
+				"@radix-ui/react-scroll-area": "^1.2.9",
+				"@radix-ui/react-slot": "^1.2.3",
+				"@visx/xychart": "^3.12.0",
+				"@wordpress/i18n": "^6.1.0",
+				"class-variance-authority": "^0.7.1",
+				"clsx": "^2.1.1",
+				"framer-motion": "^12.23.0",
+				"lucide-react": "^0.525.0",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"react-markdown": "^10.1.0",
+				"react-textarea-autosize": "^8.5.9",
+				"remark-gfm": "^4.0.1",
+				"unified": "^11.0.5",
+				"use-debounce": "^10.0.6"
+			},
+			"devDependencies": {
+				"@mdx-js/react": "^3.1.0",
+				"@storybook/addon-a11y": "^9.0.18",
+				"@storybook/addon-docs": "^9.0.18",
+				"@storybook/addon-essentials": "9.0.0-alpha.12",
+				"@storybook/addon-links": "^9.0.18",
+				"@storybook/addon-onboarding": "^9.0.18",
+				"@storybook/blocks": "9.0.0-alpha.17",
+				"@storybook/manager-api": "^8.6.14",
+				"@storybook/react": "^9.0.18",
+				"@storybook/react-vite": "^9.0.18",
+				"@storybook/test": "9.0.0-alpha.2",
+				"@types/node": "^20.0.0",
+				"@types/react": "^18.0.0",
+				"@types/react-dom": "^18.0.0",
+				"@wordpress/prettier-config": "^4.2.0",
+				"@wordpress/scripts": "^27.9.0",
+				"autoprefixer": "^10.4.0",
+				"eslint-import-resolver-typescript": "^4.4.4",
+				"jsdom": "^24.0.0",
+				"postcss": "^8.4.0",
+				"storybook": "^9.0.18",
+				"typescript": "^5.0.0",
+				"vite": "^5.0.0",
+				"vite-plugin-lib-inject-css": "^2.2.2",
+				"vitest": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"marked": "^16.2.1"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -96,186 +190,18 @@
 			"license": "ISC"
 		},
 		"node_modules/@automattic/agenttic-client": {
-			"version": "0.1.68",
-			"resolved": "https://registry.npmjs.org/@automattic/agenttic-client/-/agenttic-client-0.1.68.tgz",
-			"integrity": "sha512-pmaDwpF/q9ckm3gMgoTOBg/kAS0Kydvb2TZ0dMtmglLnwHN/65s5ZumntOHsaIykpcwKasdtQLHN/QqBtGdIgA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "^18.0.0",
-				"react": "^18.0.0"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"optionalDependencies": {
-				"marked": "^16.2.1"
-			},
-			"peerDependencies": {
-				"@wordpress/api-fetch": "^6.0.0 || ^7.0.0",
-				"react": "^18.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@wordpress/api-fetch": {
-					"optional": true
-				}
-			}
+			"resolved": "../agenttic/packages/agenttic-client",
+			"link": true
 		},
 		"node_modules/@automattic/agenttic-ui": {
-			"version": "0.1.68",
-			"resolved": "https://registry.npmjs.org/@automattic/agenttic-ui/-/agenttic-ui-0.1.68.tgz",
-			"integrity": "sha512-gXDfWTxTpebR/8NOh1q7e8PWXII9o7tJTD5ncNTWaw904L8+vHmaJm40J+G2AKuh8h8aTGqsSG+g7phkhoo3FQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@automattic/charts": ">=0.58.0 <1.0.0",
-				"@radix-ui/react-popover": "^1.1.15",
-				"@radix-ui/react-scroll-area": "^1.2.9",
-				"@radix-ui/react-slot": "^1.2.3",
-				"@visx/xychart": "^3.12.0",
-				"@wordpress/i18n": "^6.1.0",
-				"class-variance-authority": "^0.7.1",
-				"clsx": "^2.1.1",
-				"framer-motion": "^12.23.0",
-				"lucide-react": "^0.525.0",
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0",
-				"react-markdown": "^10.1.0",
-				"react-textarea-autosize": "^8.5.9",
-				"remark-gfm": "^4.0.1",
-				"unified": "^11.0.5",
-				"use-debounce": "^10.0.6"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"optionalDependencies": {
-				"marked": "^16.2.1"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@automattic/agenttic-ui/node_modules/framer-motion": {
-			"version": "12.40.0",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
-			"integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
-			"license": "MIT",
-			"dependencies": {
-				"motion-dom": "^12.40.0",
-				"motion-utils": "^12.39.0",
-				"tslib": "^2.4.0"
-			},
-			"peerDependencies": {
-				"@emotion/is-prop-valid": "*",
-				"react": "^18.0.0 || ^19.0.0",
-				"react-dom": "^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@emotion/is-prop-valid": {
-					"optional": true
-				},
-				"react": {
-					"optional": true
-				},
-				"react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@automattic/agenttic-ui/node_modules/motion-dom": {
-			"version": "12.40.0",
-			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
-			"integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
-			"license": "MIT",
-			"dependencies": {
-				"motion-utils": "^12.39.0"
-			}
-		},
-		"node_modules/@automattic/agenttic-ui/node_modules/motion-utils": {
-			"version": "12.39.0",
-			"resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
-			"integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
-			"license": "MIT"
-		},
-		"node_modules/@automattic/charts": {
-			"version": "0.59.0",
-			"resolved": "https://registry.npmjs.org/@automattic/charts/-/charts-0.59.0.tgz",
-			"integrity": "sha512-DLGIm2v9lkdKQfrkPw06HbwJGSZqSK/glRFcZXyh2FJiSvRF54T0lwjuqw6fCNzOgIlosUC7O2uRciXZP6vP5w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@automattic/number-formatters": "^1.1.2",
-				"@babel/runtime": "7.28.6",
-				"@react-spring/web": "9.7.5",
-				"@visx/annotation": "^3.12.0",
-				"@visx/axis": "^3.12.0",
-				"@visx/curve": "^3.12.0",
-				"@visx/event": "^3.12.0",
-				"@visx/gradient": "^3.12.0",
-				"@visx/grid": "^3.12.0",
-				"@visx/group": "^3.12.0",
-				"@visx/legend": "^3.12.0",
-				"@visx/pattern": "^3.12.0",
-				"@visx/responsive": "^3.12.0",
-				"@visx/scale": "^3.12.0",
-				"@visx/shape": "^3.12.0",
-				"@visx/text": "^3.12.0",
-				"@visx/tooltip": "^3.12.0",
-				"@visx/vendor": "^3.12.0",
-				"@visx/xychart": "^3.12.0",
-				"@wordpress/i18n": "^6.0.0",
-				"@wordpress/theme": "0.9.0",
-				"@wordpress/ui": "0.9.0",
-				"clsx": "2.1.1",
-				"date-fns": "^4.1.0",
-				"deepmerge": "4.3.1",
-				"fast-deep-equal": "3.1.3",
-				"gridicons": "3.4.2",
-				"react-google-charts": "^5.2.1",
-				"tslib": "2.8.1"
-			},
-			"engines": {
-				"node": ">=20.10.0"
-			},
-			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0"
-			}
-		},
-		"node_modules/@automattic/charts/node_modules/@babel/runtime": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@automattic/charts/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
-		"node_modules/@automattic/number-formatters": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@automattic/number-formatters/-/number-formatters-1.2.3.tgz",
-			"integrity": "sha512-lOQqBKpctm7dNh/6BBu6cLT+w5Yoqjup+JHhWJ4x0Zr3gzP0VpcecDiCtlqrf9XVODCZVbogH3XVDZsAEHSn4g==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/date": "^5.19.0",
-				"debug": "^4.4.0",
-				"tslib": "^2.5.0"
-			}
+			"resolved": "../agenttic/packages/agenttic-ui",
+			"link": true
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.29.0",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
 			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.28.5",
@@ -600,7 +526,7 @@
 			"version": "7.28.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
 			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -2171,6 +2097,7 @@
 			"version": "7.29.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
 			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -2224,28 +2151,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@base-ui/utils": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
-			"integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.29.2",
-				"@floating-ui/utils": "^0.2.11",
-				"reselect": "^5.2.0",
-				"use-sync-external-store": "^1.6.0"
-			},
-			"peerDependencies": {
-				"@types/react": "^17 || ^18 || ^19",
-				"react": "^17 || ^18 || ^19",
-				"react-dom": "^17 || ^18 || ^19"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@bcoe/v8-coverage": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -2257,7 +2162,7 @@
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
 			"integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cacheable/utils": "^2.4.0",
@@ -2270,7 +2175,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
 			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hashery": "^1.4.0",
@@ -2287,7 +2192,7 @@
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
 			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -2297,7 +2202,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
 			"integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hashery": "^1.5.0",
@@ -2308,7 +2213,7 @@
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
 			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -2390,7 +2295,7 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
 			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2413,7 +2318,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
 			"integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2438,7 +2343,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
 			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2482,7 +2387,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
 			"integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@date-fns/utc": {
@@ -2506,7 +2411,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
 			"integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -2606,7 +2511,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
 			"integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/memoize": "^0.9.0"
@@ -2616,7 +2521,7 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
 			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@emotion/react": {
@@ -2859,6 +2764,7 @@
 			"version": "1.7.5",
 			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
 			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/utils": "^0.2.11"
@@ -2868,6 +2774,7 @@
 			"version": "1.7.6",
 			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
 			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/core": "^1.7.5",
@@ -2878,6 +2785,7 @@
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
 			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/dom": "^1.6.1"
@@ -2891,6 +2799,7 @@
 			"version": "0.2.11",
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
 			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
@@ -3731,7 +3640,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
 			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@leichtgewicht/ip-codec": {
@@ -3768,7 +3677,7 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
@@ -3782,7 +3691,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -3792,7 +3701,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
@@ -4881,558 +4790,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@radix-ui/number": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz",
-			"integrity": "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==",
-			"license": "MIT"
-		},
-		"node_modules/@radix-ui/primitive": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
-			"integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
-			"license": "MIT"
-		},
-		"node_modules/@radix-ui/react-arrow": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz",
-			"integrity": "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-primitive": "2.1.6"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-compose-refs": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
-			"integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-context": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
-			"integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-direction": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
-			"integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-dismissable-layer": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
-			"integrity": "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.4",
-				"@radix-ui/react-compose-refs": "1.1.3",
-				"@radix-ui/react-primitive": "2.1.6",
-				"@radix-ui/react-use-callback-ref": "1.1.2",
-				"@radix-ui/react-use-escape-keydown": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-focus-guards": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
-			"integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-focus-scope": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.10.tgz",
-			"integrity": "sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-compose-refs": "1.1.3",
-				"@radix-ui/react-primitive": "2.1.6",
-				"@radix-ui/react-use-callback-ref": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-id": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
-			"integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-use-layout-effect": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-popover": {
-			"version": "1.1.17",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.17.tgz",
-			"integrity": "sha512-/YSAOdJ7YJvdn7bn5sdSx2egW+SKY+u7O5RyAVs94Ymrg2fg5QTSFPMRkzvhGyFuE4/qsmPBdrwYoZMZh/4f+g==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.4",
-				"@radix-ui/react-compose-refs": "1.1.3",
-				"@radix-ui/react-context": "1.1.4",
-				"@radix-ui/react-dismissable-layer": "1.1.13",
-				"@radix-ui/react-focus-guards": "1.1.4",
-				"@radix-ui/react-focus-scope": "1.1.10",
-				"@radix-ui/react-id": "1.1.2",
-				"@radix-ui/react-popper": "1.3.1",
-				"@radix-ui/react-portal": "1.1.12",
-				"@radix-ui/react-presence": "1.1.6",
-				"@radix-ui/react-primitive": "2.1.6",
-				"@radix-ui/react-slot": "1.3.0",
-				"@radix-ui/react-use-controllable-state": "1.2.3",
-				"aria-hidden": "^1.2.4",
-				"react-remove-scroll": "^2.7.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-popper": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.1.tgz",
-			"integrity": "sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==",
-			"license": "MIT",
-			"dependencies": {
-				"@floating-ui/react-dom": "^2.0.0",
-				"@radix-ui/react-arrow": "1.1.10",
-				"@radix-ui/react-compose-refs": "1.1.3",
-				"@radix-ui/react-context": "1.1.4",
-				"@radix-ui/react-primitive": "2.1.6",
-				"@radix-ui/react-use-callback-ref": "1.1.2",
-				"@radix-ui/react-use-layout-effect": "1.1.2",
-				"@radix-ui/react-use-rect": "1.1.2",
-				"@radix-ui/react-use-size": "1.1.2",
-				"@radix-ui/rect": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-portal": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
-			"integrity": "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-primitive": "2.1.6",
-				"@radix-ui/react-use-layout-effect": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-presence": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
-			"integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-use-layout-effect": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-primitive": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
-			"integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-slot": "1.3.0"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-scroll-area": {
-			"version": "1.2.12",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.12.tgz",
-			"integrity": "sha512-xuafVzQiTCLsyEjakowTdG3OgTXsmO7IdCiO77otIa+z44xoLNs9Do5eg7POFumIOCjtG6djfm6RKUKpUa/csA==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/number": "1.1.2",
-				"@radix-ui/primitive": "1.1.4",
-				"@radix-ui/react-compose-refs": "1.1.3",
-				"@radix-ui/react-context": "1.1.4",
-				"@radix-ui/react-direction": "1.1.2",
-				"@radix-ui/react-presence": "1.1.6",
-				"@radix-ui/react-primitive": "2.1.6",
-				"@radix-ui/react-use-callback-ref": "1.1.2",
-				"@radix-ui/react-use-layout-effect": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-slot": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
-			"integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-compose-refs": "1.1.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-use-callback-ref": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
-			"integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-use-controllable-state": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
-			"integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-use-effect-event": "0.0.3",
-				"@radix-ui/react-use-layout-effect": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-use-effect-event": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
-			"integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-use-layout-effect": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-use-escape-keydown": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
-			"integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-use-callback-ref": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-use-layout-effect": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
-			"integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-use-rect": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
-			"integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/rect": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-use-size": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
-			"integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-use-layout-effect": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/rect": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
-			"integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
-			"license": "MIT"
-		},
-		"node_modules/@react-spring/animated": {
-			"version": "9.7.5",
-			"resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
-			"integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
-			"license": "MIT",
-			"dependencies": {
-				"@react-spring/shared": "~9.7.5",
-				"@react-spring/types": "~9.7.5"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-			}
-		},
-		"node_modules/@react-spring/core": {
-			"version": "9.7.5",
-			"resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
-			"integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
-			"license": "MIT",
-			"dependencies": {
-				"@react-spring/animated": "~9.7.5",
-				"@react-spring/shared": "~9.7.5",
-				"@react-spring/types": "~9.7.5"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/react-spring/donate"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-			}
-		},
-		"node_modules/@react-spring/rafz": {
-			"version": "9.7.5",
-			"resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
-			"integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
-			"license": "MIT"
-		},
-		"node_modules/@react-spring/shared": {
-			"version": "9.7.5",
-			"resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
-			"integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
-			"license": "MIT",
-			"dependencies": {
-				"@react-spring/rafz": "~9.7.5",
-				"@react-spring/types": "~9.7.5"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-			}
-		},
-		"node_modules/@react-spring/types": {
-			"version": "9.7.5",
-			"resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
-			"integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
-			"license": "MIT"
-		},
-		"node_modules/@react-spring/web": {
-			"version": "9.7.5",
-			"resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
-			"integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@react-spring/animated": "~9.7.5",
-				"@react-spring/core": "~9.7.5",
-				"@react-spring/shared": "~9.7.5",
-				"@react-spring/types": "~9.7.5"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-			}
-		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -6021,99 +5378,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/d3-array": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
-			"integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-color": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
-			"integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-delaunay": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
-			"integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-format": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
-			"integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-geo": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-			"integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/geojson": "*"
-			}
-		},
-		"node_modules/@types/d3-interpolate": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-			"integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-color": "*"
-			}
-		},
-		"node_modules/@types/d3-path": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
-			"integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-scale": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
-			"integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-time": "*"
-			}
-		},
-		"node_modules/@types/d3-shape": {
-			"version": "1.3.12",
-			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
-			"integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-path": "^1"
-			}
-		},
-		"node_modules/@types/d3-time": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
-			"integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-time-format": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
-			"integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-voronoi": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
-			"integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/debug": {
-			"version": "4.1.13",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
-			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/ms": "*"
-			}
-		},
 		"node_modules/@types/eslint": {
 			"version": "9.6.1",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -6140,16 +5404,8 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@types/estree-jsx": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
-			"integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "*"
-			}
 		},
 		"node_modules/@types/express": {
 			"version": "4.17.25",
@@ -6190,12 +5446,6 @@
 				"@types/send": "*"
 			}
 		},
-		"node_modules/@types/geojson": {
-			"version": "7946.0.16",
-			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-			"license": "MIT"
-		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -6212,15 +5462,6 @@
 			"integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@types/hast": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
 		},
 		"node_modules/@types/highlight-words-core": {
 			"version": "1.2.1",
@@ -6299,21 +5540,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/lodash": {
-			"version": "4.17.24",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-			"integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-			"license": "MIT"
-		},
-		"node_modules/@types/mdast": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/@types/mime": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -6332,12 +5558,7 @@
 			"version": "1.6.15",
 			"resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
 			"integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/ms": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/mysql": {
@@ -6541,12 +5762,6 @@
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
 			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/unist": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
 			"license": "MIT"
 		},
 		"node_modules/@types/wordpress__block-editor": {
@@ -6933,6 +6148,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
@@ -7224,383 +6440,6 @@
 				"react": ">= 16.8.0"
 			}
 		},
-		"node_modules/@visx/annotation": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/annotation/-/annotation-3.12.0.tgz",
-			"integrity": "sha512-ZH6Y4jfrb47iEUV9O2itU9TATE5IPzhs5qvP6J7vmv26qkqwDcuE7xN3S3l9R70WjyEKGbpO8js4EijA3FJWkA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"@visx/drag": "3.12.0",
-				"@visx/group": "3.12.0",
-				"@visx/text": "3.12.0",
-				"classnames": "^2.3.1",
-				"prop-types": "^15.5.10",
-				"react-use-measure": "^2.0.4"
-			},
-			"peerDependencies": {
-				"react": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/axis": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/axis/-/axis-3.12.0.tgz",
-			"integrity": "sha512-8MoWpfuaJkhm2Yg+HwyytK8nk+zDugCqTT/tRmQX7gW4LYrHYLXFUXOzbDyyBakCVaUbUaAhVFxpMASJiQKf7A==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"@visx/group": "3.12.0",
-				"@visx/point": "3.12.0",
-				"@visx/scale": "3.12.0",
-				"@visx/shape": "3.12.0",
-				"@visx/text": "3.12.0",
-				"classnames": "^2.3.1",
-				"prop-types": "^15.6.0"
-			},
-			"peerDependencies": {
-				"react": "^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/bounds": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/bounds/-/bounds-3.12.0.tgz",
-			"integrity": "sha512-peAlNCUbYaaZ0IO6c1lDdEAnZv2iGPDiLIM8a6gu7CaMhtXZJkqrTh+AjidNcIqITktrICpGxJE/Qo9D099dvQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"prop-types": "^15.5.10"
-			},
-			"peerDependencies": {
-				"react": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0",
-				"react-dom": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/curve": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/curve/-/curve-3.12.0.tgz",
-			"integrity": "sha512-Ng1mefXIzoIoAivw7dJ+ZZYYUbfuwXgZCgQynShr6ZIVw7P4q4HeQfJP3W24ON+1uCSrzoycHSXRelhR9SBPcw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-shape": "^1.3.1",
-				"d3-shape": "^1.0.6"
-			}
-		},
-		"node_modules/@visx/drag": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/drag/-/drag-3.12.0.tgz",
-			"integrity": "sha512-LXOoPVw//YPjpYhDJYBsCYDuv1QimsXjDV98duH0aCy4V94ediXMQpe2wHq4pnlDobLEB71FjOZMFrbFmqtERg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"@visx/event": "3.12.0",
-				"@visx/point": "3.12.0",
-				"prop-types": "^15.5.10"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/event": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/event/-/event-3.12.0.tgz",
-			"integrity": "sha512-9Lvw6qJ0Fi+y1vsC1WspfdIKCxHTb7oy59Uql1uBdPGT8zChP0vuxW0jQNQRDbKgoefj4pCXAFi8+MF1mEtVTw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"@visx/point": "3.12.0"
-			}
-		},
-		"node_modules/@visx/glyph": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/glyph/-/glyph-3.12.0.tgz",
-			"integrity": "sha512-E9ST9MoPNyXQzjZxYYAGXT4CbBpnB90Qhx8UvUUM2/n/SZUNeH+m6UiB/CzT0jGK2b0lPHF91mlOiQ8JXBRhYg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-shape": "^1.3.1",
-				"@types/react": "*",
-				"@visx/group": "3.12.0",
-				"classnames": "^2.3.1",
-				"d3-shape": "^1.2.0",
-				"prop-types": "^15.6.2"
-			},
-			"peerDependencies": {
-				"react": "^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/gradient": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/gradient/-/gradient-3.12.0.tgz",
-			"integrity": "sha512-QRatjjdUEPbcp4pqRca1JlChpAnmmIAO3r3ZscLK7D1xEIANlIjzjl3uNgrmseYmBAYyPCcJH8Zru07R97ovOg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"prop-types": "^15.5.7"
-			},
-			"peerDependencies": {
-				"react": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/grid": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/grid/-/grid-3.12.0.tgz",
-			"integrity": "sha512-L4ex2ooSYhwNIxJ3XFIKRhoSvEGjPc2Y3YCrtNB4TV5Ofdj4q0UMOsxfrH23Pr8HSHuQhb6VGMgYoK0LuWqDmQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"@visx/curve": "3.12.0",
-				"@visx/group": "3.12.0",
-				"@visx/point": "3.12.0",
-				"@visx/scale": "3.12.0",
-				"@visx/shape": "3.12.0",
-				"classnames": "^2.3.1",
-				"prop-types": "^15.6.2"
-			},
-			"peerDependencies": {
-				"react": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/group": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/group/-/group-3.12.0.tgz",
-			"integrity": "sha512-Dye8iS1alVXPv7nj/7M37gJe6sSKqJLH7x6sEWAsRQ9clI0kFvjbKcKgF+U3aAVQr0NCohheFV+DtR8trfK/Ag==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"classnames": "^2.3.1",
-				"prop-types": "^15.6.2"
-			},
-			"peerDependencies": {
-				"react": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/legend": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/legend/-/legend-3.12.0.tgz",
-			"integrity": "sha512-Tr6hdauEDXRXVNeNgIQ9JtCCrxn8Fbr8UCVlO9XsSxenk2hBC/2PIY5QPzpnKFEEEuH/C8vhj8T0JfFZV+D9zQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"@visx/group": "3.12.0",
-				"@visx/scale": "3.12.0",
-				"classnames": "^2.3.1",
-				"prop-types": "^15.5.10"
-			},
-			"peerDependencies": {
-				"react": "^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/pattern": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/pattern/-/pattern-3.12.0.tgz",
-			"integrity": "sha512-ZkNA/2TkULNiiY4cw2IkuQcQRp9zI3SQ0/JoZMQ+UmUvY5RNBcsdTmic7649egHq0FRYCbY0DDQVJicccW5JUg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"classnames": "^2.3.1",
-				"prop-types": "^15.5.10"
-			},
-			"peerDependencies": {
-				"react": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/point": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/point/-/point-3.12.0.tgz",
-			"integrity": "sha512-I6UrHoJAEVbx3RORQNupgTiX5EzjuZpiwLPxn8L2mI5nfERotPKi1Yus12Cq2WtXqEBR/WgqTnoImlqOXBykcA==",
-			"license": "MIT"
-		},
-		"node_modules/@visx/react-spring": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/react-spring/-/react-spring-3.12.0.tgz",
-			"integrity": "sha512-ehtmjFrUQx3g0mZ684M4LgI9UfQ84ZWD/m9tKfvXhEm1Vl8D4AjaZ4af1tTOg9S7vk2VlpxvVOVN7+t5pu0nSA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"@visx/axis": "3.12.0",
-				"@visx/grid": "3.12.0",
-				"@visx/scale": "3.12.0",
-				"@visx/text": "3.12.0",
-				"classnames": "^2.3.1",
-				"prop-types": "^15.6.2"
-			},
-			"peerDependencies": {
-				"@react-spring/web": "^9.4.5",
-				"react": "^16.3.0-0 || ^17.0.0 || ^18.0.0"
-			}
-		},
-		"node_modules/@visx/responsive": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/responsive/-/responsive-3.12.0.tgz",
-			"integrity": "sha512-GV1BTYwAGlk/K5c9vH8lS2syPnTuIqEacI7L6LRPbsuaLscXMNi+i9fZyzo0BWvAdtRV8v6Urzglo++lvAXT1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/lodash": "^4.14.172",
-				"@types/react": "*",
-				"lodash": "^4.17.21",
-				"prop-types": "^15.6.1"
-			},
-			"peerDependencies": {
-				"react": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/scale": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/scale/-/scale-3.12.0.tgz",
-			"integrity": "sha512-+ubijrZ2AwWCsNey0HGLJ0YKNeC/XImEFsr9rM+Uef1CM3PNM43NDdNTrdBejSlzRq0lcfQPWYMYQFSlkLcPOg==",
-			"license": "MIT",
-			"dependencies": {
-				"@visx/vendor": "3.12.0"
-			}
-		},
-		"node_modules/@visx/shape": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/shape/-/shape-3.12.0.tgz",
-			"integrity": "sha512-/1l0lrpX9tPic6SJEalryBKWjP/ilDRnQA+BGJTI1tj7i23mJ/J0t4nJHyA1GrL4QA/bM/qTJ35eyz5dEhJc4g==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-path": "^1.0.8",
-				"@types/d3-shape": "^1.3.1",
-				"@types/lodash": "^4.14.172",
-				"@types/react": "*",
-				"@visx/curve": "3.12.0",
-				"@visx/group": "3.12.0",
-				"@visx/scale": "3.12.0",
-				"classnames": "^2.3.1",
-				"d3-path": "^1.0.5",
-				"d3-shape": "^1.2.0",
-				"lodash": "^4.17.21",
-				"prop-types": "^15.5.10"
-			},
-			"peerDependencies": {
-				"react": "^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/text": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/text/-/text-3.12.0.tgz",
-			"integrity": "sha512-0rbDYQlbuKPhBqXkkGYKFec1gQo05YxV45DORzr6hCyaizdJk1G+n9VkuKSHKBy1vVQhBA0W3u/WXd7tiODQPA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/lodash": "^4.14.172",
-				"@types/react": "*",
-				"classnames": "^2.3.1",
-				"lodash": "^4.17.21",
-				"prop-types": "^15.7.2",
-				"reduce-css-calc": "^1.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/tooltip": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/tooltip/-/tooltip-3.12.0.tgz",
-			"integrity": "sha512-pWhsYhgl0Shbeqf80qy4QCB6zpq6tQtMQQxKlh3UiKxzkkfl+Metaf9p0/S0HexNi4vewOPOo89xWx93hBeh3A==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/react": "*",
-				"@visx/bounds": "3.12.0",
-				"classnames": "^2.3.1",
-				"prop-types": "^15.5.10",
-				"react-use-measure": "^2.0.4"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0",
-				"react-dom": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/vendor": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/vendor/-/vendor-3.12.0.tgz",
-			"integrity": "sha512-SVO+G0xtnL9dsNpGDcjCgoiCnlB3iLSM9KLz1sLbSrV7RaVXwY3/BTm2X9OWN1jH2a9M+eHt6DJ6sE6CXm4cUg==",
-			"license": "MIT and ISC",
-			"dependencies": {
-				"@types/d3-array": "3.0.3",
-				"@types/d3-color": "3.1.0",
-				"@types/d3-delaunay": "6.0.1",
-				"@types/d3-format": "3.0.1",
-				"@types/d3-geo": "3.1.0",
-				"@types/d3-interpolate": "3.0.1",
-				"@types/d3-scale": "4.0.2",
-				"@types/d3-time": "3.0.0",
-				"@types/d3-time-format": "2.1.0",
-				"d3-array": "3.2.1",
-				"d3-color": "3.1.0",
-				"d3-delaunay": "6.0.2",
-				"d3-format": "3.1.0",
-				"d3-geo": "3.1.0",
-				"d3-interpolate": "3.0.1",
-				"d3-scale": "4.0.2",
-				"d3-time": "3.1.0",
-				"d3-time-format": "4.1.0",
-				"internmap": "2.0.3"
-			}
-		},
-		"node_modules/@visx/voronoi": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/voronoi/-/voronoi-3.12.0.tgz",
-			"integrity": "sha512-U3HWu6g5UjQchFDq8k/A4U9WrlN+80rAFPdGOUvIGOueQw9RmlZlNaeg8IJcQr2yk1s4O/VSpt3nR82zdINWMw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-voronoi": "^1.1.9",
-				"@types/react": "*",
-				"classnames": "^2.3.1",
-				"d3-voronoi": "^1.1.2",
-				"prop-types": "^15.6.1"
-			},
-			"peerDependencies": {
-				"react": "^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0"
-			}
-		},
-		"node_modules/@visx/xychart": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@visx/xychart/-/xychart-3.12.0.tgz",
-			"integrity": "sha512-itJ7qvj/STpVmHesVyo2vPOataBM1mgSaf9R6/s4Bpe340wZldfCJ+IqRcNgdtbBagz1Hlr/sRnla4tWE2yw9A==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/lodash": "^4.14.172",
-				"@types/react": "*",
-				"@visx/annotation": "3.12.0",
-				"@visx/axis": "3.12.0",
-				"@visx/event": "3.12.0",
-				"@visx/glyph": "3.12.0",
-				"@visx/grid": "3.12.0",
-				"@visx/react-spring": "3.12.0",
-				"@visx/responsive": "3.12.0",
-				"@visx/scale": "3.12.0",
-				"@visx/shape": "3.12.0",
-				"@visx/text": "3.12.0",
-				"@visx/tooltip": "3.12.0",
-				"@visx/vendor": "3.12.0",
-				"@visx/voronoi": "3.12.0",
-				"classnames": "^2.3.1",
-				"d3-interpolate-path": "2.2.1",
-				"d3-shape": "^2.0.0",
-				"lodash": "^4.17.21",
-				"mitt": "^2.1.0",
-				"prop-types": "^15.6.2"
-			},
-			"peerDependencies": {
-				"@react-spring/web": "^9.4.5",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-			}
-		},
-		"node_modules/@visx/xychart/node_modules/d3-shape": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
-			"integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"d3-path": "1 - 2"
-			}
-		},
-		"node_modules/@visx/xychart/node_modules/mitt": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
-			"integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==",
-			"license": "MIT"
-		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -7813,6 +6652,7 @@
 			"version": "4.42.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.42.0.tgz",
 			"integrity": "sha512-7NdHXJt3XDBXujkhoZkuBzZJIY+LrG0r2aPSJVujoHwioBR3V+HgdcGa1xydAnKtdiNnYa8fEdlWqk49EEQ0MA==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/dom-ready": "^4.42.0",
@@ -8206,6 +7046,7 @@
 			"version": "7.42.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.42.0.tgz",
 			"integrity": "sha512-SME943pAezFMmC/KRXE2VVrc4zGawLjIo4Bv1b6KN6f5M40ni7l3Us7vmuzDFuiX3wQubdi7XEFmrDr/jiDrsA==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
@@ -8262,6 +7103,7 @@
 			"version": "5.42.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.42.0.tgz",
 			"integrity": "sha512-iTzp5vkJm3lX2V2vRdu1PK/Z9LNREWGSic5yYNKTxmOXd7FUu93hCb4hfxYReJHRqSq8lQORbvxxF/b3JeM3yA==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/deprecated": "^4.42.0",
@@ -8301,6 +7143,7 @@
 			"version": "4.48.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.48.1.tgz",
 			"integrity": "sha512-ZfJSCxWr4Ss5qGja9W7L6+8vcrbX0n+tKDe2TrYvTq6GiqEc+0MrajIl4vi/58jhceHbSze1ITX/ocC3Ed3NLg==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/hooks": "^4.48.1"
@@ -8314,6 +7157,7 @@
 			"version": "4.42.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.42.0.tgz",
 			"integrity": "sha512-LRyfQEkAcDyVvFt7pMO9jOVE1X32N9Kef/WBUFfdT0NjPPLHG/iYIDmiyXNrvpxcLrBPxWZqr0jvuFEudlrwXw==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/deprecated": "^4.42.0"
@@ -8327,6 +7171,7 @@
 			"version": "4.42.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.42.0.tgz",
 			"integrity": "sha512-ujShJCmo9Y6yqX9tD7100M7MwiEPiDsaN2OQzX1vA+2lp099muq73376zv9ISBkK0C8uUbMZzw2B+JTmBiyGtw==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -8533,6 +7378,7 @@
 			"version": "5.42.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.42.0.tgz",
 			"integrity": "sha512-o2nEnBeUvGv5vT6uV2ed/7UcFWlSMFmRRtcDqQomPledVOHpAZfrRWawuSFEC61PMFqclp7kGfNLSHfhoG1J+A==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -8580,6 +7426,7 @@
 			"version": "4.42.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.42.0.tgz",
 			"integrity": "sha512-QV82RsOYL3qWXxVTU7T6zk5LU1ad4YP6DDH4czQR8mJECoDsblf2gSjYcGDHkPUK30SXJ7/x/ZOnhGkyJSVaKw==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/i18n": "^6.15.0"
@@ -8640,6 +7487,7 @@
 			"version": "4.48.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.48.1.tgz",
 			"integrity": "sha512-nzAcsXhBxw9x2q/ImVa45Ft80TO+e/WgCDmWaU3Zb2trogwThxZTezkE0oeQ6PSxSeGYM6nBgk+qqFCG8wyMhQ==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
@@ -8658,6 +7506,7 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.1.tgz",
 			"integrity": "sha512-otYhxfm6ZKkcLCl/tI1rB70z6MVDvTL+RiPOWXi4qm0niJf4isSXCcB91ffj1gzJXKbEpszHfysIoU9L2gCSGQ==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
@@ -8678,6 +7527,7 @@
 			"version": "3.42.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.42.0.tgz",
 			"integrity": "sha512-XNi5PWOCz6Y8YSNl7PDNx+CPoADxzRvYhfxCdzJbX4Za5HZi7/qfrIIUI6GIETRPRvWSCI9TZmctRFjBg1mq3Q==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"requestidlecallback": "^0.3.0"
@@ -8691,6 +7541,7 @@
 			"version": "1.42.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.42.0.tgz",
 			"integrity": "sha512-IDpyCszdnBECvkejn2vyGPHn4aWtROFq0yFaVGPAvYCadnlpWsQC0oJodppBOE7sftYiIDnTw6/rnv+mp29/Kg==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -8883,6 +7734,7 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.9.0.tgz",
 			"integrity": "sha512-jxskNZVvWHIswQvWvswaNIAkBpXwdFcocBYxTWQnYgvb0QAEYsKsnqYMulZPrz/Dk4c+GF7ptwdLxb3rry9tcg==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "^6.42.0",
@@ -8905,106 +7757,11 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/ui": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.9.0.tgz",
-			"integrity": "sha512-PXx0CU5ngJOaC69ylhyyS33Ac4njVudGMkrPjXuRd6cXZeizD3q6KO0ws1ECtm4FYlrWv5YvYyNhT5salP9hTg==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@base-ui/react": "^1.2.0",
-				"@wordpress/a11y": "^4.42.0",
-				"@wordpress/compose": "^7.42.0",
-				"@wordpress/element": "^6.42.0",
-				"@wordpress/i18n": "^6.15.0",
-				"@wordpress/icons": "^12.0.0",
-				"@wordpress/keycodes": "^4.42.0",
-				"@wordpress/primitives": "^4.42.0",
-				"@wordpress/private-apis": "^1.42.0",
-				"@wordpress/theme": "^0.9.0",
-				"clsx": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/ui/node_modules/@base-ui/react": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.29.2",
-				"@base-ui/utils": "0.3.1",
-				"@floating-ui/react-dom": "^2.1.8",
-				"@floating-ui/utils": "^0.2.11",
-				"use-sync-external-store": "^1.6.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui-org"
-			},
-			"peerDependencies": {
-				"@date-fns/tz": "^1.2.0",
-				"@types/react": "^17 || ^18 || ^19",
-				"date-fns": "^4.0.0",
-				"react": "^17 || ^18 || ^19",
-				"react-dom": "^17 || ^18 || ^19"
-			},
-			"peerDependenciesMeta": {
-				"@date-fns/tz": {
-					"optional": true
-				},
-				"@types/react": {
-					"optional": true
-				},
-				"date-fns": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/ui/node_modules/@floating-ui/react-dom": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-			"integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-			"license": "MIT",
-			"dependencies": {
-				"@floating-ui/dom": "^1.7.6"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
-			}
-		},
-		"node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
-			"version": "12.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-12.2.0.tgz",
-			"integrity": "sha512-Fiw7bmfHDNPjTdCrBF23/9K0VN/GUi73d2ZPZaeWdXhTmIX62T9KYvb1c+WnlBkX7GpXgJO6Q8mypQCY9mw5SQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^6.44.0",
-				"@wordpress/primitives": "^4.44.0",
-				"change-case": "4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
 		"node_modules/@wordpress/undo-manager": {
 			"version": "1.42.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.42.0.tgz",
 			"integrity": "sha512-FczZFHqFY0R5z2PyYEa/Dsc7mR2PhWAX05at274m0Z/wlPeOx2VnZn0L5Vs4mDEOlF13r17Mn+7VRLtjm5lxTQ==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/is-shallow-equal": "^5.42.0"
@@ -9298,7 +8055,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -9308,7 +8065,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -9352,18 +8109,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
-			}
-		},
-		"node_modules/aria-hidden": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-			"integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/aria-query": {
@@ -9437,7 +8182,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -9597,7 +8342,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -9915,20 +8660,11 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"node_modules/bail": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
-			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/bare-events": {
@@ -10189,7 +8925,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -10311,7 +9047,7 @@
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz",
 			"integrity": "sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cacheable/memory": "^2.0.8",
@@ -10325,7 +9061,7 @@
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
 			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -10385,7 +9121,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -10487,16 +9223,6 @@
 				"upper-case-first": "^2.0.2"
 			}
 		},
-		"node_modules/ccount": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -10542,46 +9268,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/character-entities": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/character-entities-html4": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/character-entities-legacy": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/character-reference-invalid": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
-			"integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/check-node-version": {
@@ -10701,24 +9387,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/class-variance-authority": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
-			"integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"clsx": "^2.1.1"
-			},
-			"funding": {
-				"url": "https://polar.sh/cva"
-			}
-		},
-		"node_modules/classnames": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-			"license": "MIT"
-		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -10768,6 +9436,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
 			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -10795,7 +9464,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -10808,14 +9477,14 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
 			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/colorette": {
@@ -10829,6 +9498,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
 			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -10846,16 +9516,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/comma-separated-tokens": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/commander": {
@@ -11259,7 +9919,7 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
 			"integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -11335,7 +9995,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
 			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.27.1",
@@ -11362,7 +10022,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"cssesc": "bin/cssesc"
@@ -11520,139 +10180,6 @@
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/d3-array": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
-			"integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
-			"license": "ISC",
-			"dependencies": {
-				"internmap": "1 - 2"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-color": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-delaunay": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
-			"integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
-			"license": "ISC",
-			"dependencies": {
-				"delaunator": "5"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-format": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-			"integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-geo": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
-			"integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "2.5.0 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-interpolate": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-color": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-interpolate-path": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/d3-interpolate-path/-/d3-interpolate-path-2.2.1.tgz",
-			"integrity": "sha512-6qLLh/KJVzls0XtMsMpcxhqMhgVEN7VIbR/6YGZe2qlS8KDgyyVB20XcmGnDyB051HcefQXM/Tppa9vcANEA4Q==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/d3-path": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/d3-scale": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "2.10.0 - 3",
-				"d3-format": "1 - 3",
-				"d3-interpolate": "1.2.0 - 3",
-				"d3-time": "2.1.1 - 3",
-				"d3-time-format": "2 - 4"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-shape": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"d3-path": "1"
-			}
-		},
-		"node_modules/d3-time": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "2 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-time-format": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-time": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-voronoi": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
-			"integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==",
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/damerau-levenshtein": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -11767,6 +10294,7 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -11824,19 +10352,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/decode-named-character-reference": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
-			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-			"license": "MIT",
-			"dependencies": {
-				"character-entities": "^2.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/dedent": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -11873,6 +10388,7 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -11952,15 +10468,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/delaunator": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
-			"integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
-			"license": "ISC",
-			"dependencies": {
-				"robust-predicates": "^3.0.2"
-			}
-		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -11979,15 +10486,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/dequal": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/destroy": {
@@ -12029,25 +10527,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/detect-node-es": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-			"license": "MIT"
-		},
-		"node_modules/devlop": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-			"license": "MIT",
-			"dependencies": {
-				"dequal": "^2.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/devtools-protocol": {
 			"version": "0.0.1507524",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
@@ -12069,7 +10548,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-type": "^4.0.0"
@@ -12342,7 +10821,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
 			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -12372,7 +10851,7 @@
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
 			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-arrayish": "^0.2.1"
@@ -13537,16 +12016,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/estree-util-is-identifier-name": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
-			"integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -13735,12 +12204,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"license": "MIT"
-		},
 		"node_modules/extract-zip": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -13782,6 +12245,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-diff": {
@@ -13802,7 +12266,7 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
 			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -13819,7 +12283,7 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
@@ -13846,7 +12310,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
 			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -13863,7 +12327,7 @@
 			"version": "1.0.16",
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
 			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4.9.1"
@@ -13873,7 +12337,7 @@
 			"version": "1.20.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
 			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -13957,7 +12421,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -14118,7 +12582,7 @@
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
 			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/follow-redirects": {
@@ -14402,15 +12866,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/get-nonce": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/get-package-type": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -14676,7 +13131,7 @@
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"array-union": "^2.1.0",
@@ -14697,7 +13152,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
 			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/gopd": {
@@ -14735,18 +13190,6 @@
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/gridicons": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/gridicons/-/gridicons-3.4.2.tgz",
-			"integrity": "sha512-KC2BzPDh3F0vJzYa7KYBWJOO9gTHoKoFiHNazZEU9Gq2jIJ2zObOA67wlZjZkPHPCjZiLQrko3AYFLrMrHXKrA==",
-			"license": "GPL-2.0+",
-			"dependencies": {
-				"prop-types": "^15.5.7"
-			},
-			"peerDependencies": {
-				"react": "15 - 18"
-			}
 		},
 		"node_modules/gzip-size": {
 			"version": "6.0.0",
@@ -14798,7 +13241,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -14866,7 +13309,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
 			"integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hookified": "^1.15.0"
@@ -14886,46 +13329,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/hast-util-to-jsx-runtime": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
-			"integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0",
-				"@types/hast": "^3.0.0",
-				"@types/unist": "^3.0.0",
-				"comma-separated-tokens": "^2.0.0",
-				"devlop": "^1.0.0",
-				"estree-util-is-identifier-name": "^3.0.0",
-				"hast-util-whitespace": "^3.0.0",
-				"mdast-util-mdx-expression": "^2.0.0",
-				"mdast-util-mdx-jsx": "^3.0.0",
-				"mdast-util-mdxjs-esm": "^2.0.0",
-				"property-information": "^7.0.0",
-				"space-separated-tokens": "^2.0.0",
-				"style-to-js": "^1.0.0",
-				"unist-util-position": "^5.0.0",
-				"vfile-message": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/hast-util-whitespace": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-			"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/header-case": {
@@ -14979,7 +13382,7 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
 			"integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/hosted-git-info": {
@@ -15116,23 +13519,13 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
 			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/html-url-attributes": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
-			"integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/http-deceiver": {
@@ -15308,7 +13701,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -15369,7 +13762,7 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
 			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"parent-module": "^1.0.0",
@@ -15386,7 +13779,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -15442,7 +13835,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
@@ -15481,14 +13874,8 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/inline-style-parser": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
-			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
-			"license": "MIT"
 		},
 		"node_modules/internal-slot": {
 			"version": "1.1.0",
@@ -15503,15 +13890,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/internmap": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/interpret": {
@@ -15567,30 +13945,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-alphabetical": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
-			"integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/is-alphanumerical": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
-			"integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-			"license": "MIT",
-			"dependencies": {
-				"is-alphabetical": "^2.0.0",
-				"is-decimal": "^2.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/is-array-buffer": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -15613,7 +13967,7 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/is-async-function": {
@@ -15792,16 +14146,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-decimal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
-			"integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/is-docker": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -15832,7 +14176,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -15858,7 +14202,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -15898,23 +14242,13 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-hexadecimal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
-			"integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/is-map": {
@@ -15947,7 +14281,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -16221,7 +14555,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/isobject": {
@@ -17282,7 +15616,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
@@ -17389,7 +15723,7 @@
 			"version": "0.37.0",
 			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
 			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/language-subtag-registry": {
@@ -17685,7 +16019,7 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/linkify-it": {
@@ -17744,6 +16078,7 @@
 			"version": "4.17.23",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
 			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
@@ -17778,7 +16113,7 @@
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
 			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.uniq": {
@@ -17819,16 +16154,6 @@
 				"url": "https://tidelift.com/funding/github/npm/loglevel"
 			}
 		},
-		"node_modules/longest-streak": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/lookup-closest-locale": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
@@ -17865,15 +16190,6 @@
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
-			}
-		},
-		"node_modules/lucide-react": {
-			"version": "0.525.0",
-			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
-			"integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
-			"license": "ISC",
-			"peerDependencies": {
-				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/make-dir": {
@@ -17967,16 +16283,6 @@
 			"license": "BSD-2-Clause",
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/markdown-table": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
-			"integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/markdownlint": {
@@ -18088,31 +16394,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/marked": {
-			"version": "16.4.2",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-			"integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
-			"license": "MIT",
-			"optional": true,
-			"bin": {
-				"marked": "bin/marked.js"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
 		"node_modules/marky": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
 			"integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
 			"dev": true,
 			"license": "Apache-2.0"
-		},
-		"node_modules/math-expression-evaluator": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.4.0.tgz",
-			"integrity": "sha512-4vRUvPyxdO8cWULGTh9dZWL2tZK6LDBvj+OGHBER7poH9Qdt7kXEoj20wiz4lQUbUXQZFjPbe5mVDo9nutizCw==",
-			"license": "MIT"
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
@@ -18128,300 +16415,18 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
 			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/mdast-util-find-and-replace": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
-			"integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"escape-string-regexp": "^5.0.0",
-				"unist-util-is": "^6.0.0",
-				"unist-util-visit-parents": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/mdast-util-from-markdown": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
-			"integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"@types/unist": "^3.0.0",
-				"decode-named-character-reference": "^1.0.0",
-				"devlop": "^1.0.0",
-				"mdast-util-to-string": "^4.0.0",
-				"micromark": "^4.0.0",
-				"micromark-util-decode-numeric-character-reference": "^2.0.0",
-				"micromark-util-decode-string": "^2.0.0",
-				"micromark-util-normalize-identifier": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0",
-				"unist-util-stringify-position": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
-			"integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
-			"license": "MIT",
-			"dependencies": {
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-gfm-autolink-literal": "^2.0.0",
-				"mdast-util-gfm-footnote": "^2.0.0",
-				"mdast-util-gfm-strikethrough": "^2.0.0",
-				"mdast-util-gfm-table": "^2.0.0",
-				"mdast-util-gfm-task-list-item": "^2.0.0",
-				"mdast-util-to-markdown": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-autolink-literal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-			"integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"ccount": "^2.0.0",
-				"devlop": "^1.0.0",
-				"mdast-util-find-and-replace": "^3.0.0",
-				"micromark-util-character": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-footnote": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
-			"integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"devlop": "^1.1.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-to-markdown": "^2.0.0",
-				"micromark-util-normalize-identifier": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-strikethrough": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
-			"integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-to-markdown": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-table": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
-			"integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"devlop": "^1.0.0",
-				"markdown-table": "^3.0.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-to-markdown": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-task-list-item": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
-			"integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"devlop": "^1.0.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-to-markdown": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-mdx-expression": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
-			"integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree-jsx": "^1.0.0",
-				"@types/hast": "^3.0.0",
-				"@types/mdast": "^4.0.0",
-				"devlop": "^1.0.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-to-markdown": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-mdx-jsx": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
-			"integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree-jsx": "^1.0.0",
-				"@types/hast": "^3.0.0",
-				"@types/mdast": "^4.0.0",
-				"@types/unist": "^3.0.0",
-				"ccount": "^2.0.0",
-				"devlop": "^1.1.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-to-markdown": "^2.0.0",
-				"parse-entities": "^4.0.0",
-				"stringify-entities": "^4.0.0",
-				"unist-util-stringify-position": "^4.0.0",
-				"vfile-message": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-mdxjs-esm": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
-			"integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree-jsx": "^1.0.0",
-				"@types/hast": "^3.0.0",
-				"@types/mdast": "^4.0.0",
-				"devlop": "^1.0.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-to-markdown": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-phrasing": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
-			"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"unist-util-is": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-to-hast": {
-			"version": "13.2.1",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
-			"integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"@types/mdast": "^4.0.0",
-				"@ungap/structured-clone": "^1.0.0",
-				"devlop": "^1.0.0",
-				"micromark-util-sanitize-uri": "^2.0.0",
-				"trim-lines": "^3.0.0",
-				"unist-util-position": "^5.0.0",
-				"unist-util-visit": "^5.0.0",
-				"vfile": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-to-markdown": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
-			"integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"@types/unist": "^3.0.0",
-				"longest-streak": "^3.0.0",
-				"mdast-util-phrasing": "^4.0.0",
-				"mdast-util-to-string": "^4.0.0",
-				"micromark-util-classify-character": "^2.0.0",
-				"micromark-util-decode-string": "^2.0.0",
-				"unist-util-visit": "^5.0.0",
-				"zwitch": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-to-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-			"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/mdn-data": {
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
 			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/mdurl": {
@@ -18546,7 +16551,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -18569,574 +16574,11 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/micromark": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
-			"integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@types/debug": "^4.0.0",
-				"debug": "^4.0.0",
-				"decode-named-character-reference": "^1.0.0",
-				"devlop": "^1.0.0",
-				"micromark-core-commonmark": "^2.0.0",
-				"micromark-factory-space": "^2.0.0",
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-chunked": "^2.0.0",
-				"micromark-util-combine-extensions": "^2.0.0",
-				"micromark-util-decode-numeric-character-reference": "^2.0.0",
-				"micromark-util-encode": "^2.0.0",
-				"micromark-util-normalize-identifier": "^2.0.0",
-				"micromark-util-resolve-all": "^2.0.0",
-				"micromark-util-sanitize-uri": "^2.0.0",
-				"micromark-util-subtokenize": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-core-commonmark": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
-			"integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"decode-named-character-reference": "^1.0.0",
-				"devlop": "^1.0.0",
-				"micromark-factory-destination": "^2.0.0",
-				"micromark-factory-label": "^2.0.0",
-				"micromark-factory-space": "^2.0.0",
-				"micromark-factory-title": "^2.0.0",
-				"micromark-factory-whitespace": "^2.0.0",
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-chunked": "^2.0.0",
-				"micromark-util-classify-character": "^2.0.0",
-				"micromark-util-html-tag-name": "^2.0.0",
-				"micromark-util-normalize-identifier": "^2.0.0",
-				"micromark-util-resolve-all": "^2.0.0",
-				"micromark-util-subtokenize": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-extension-gfm": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
-			"integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
-			"license": "MIT",
-			"dependencies": {
-				"micromark-extension-gfm-autolink-literal": "^2.0.0",
-				"micromark-extension-gfm-footnote": "^2.0.0",
-				"micromark-extension-gfm-strikethrough": "^2.0.0",
-				"micromark-extension-gfm-table": "^2.0.0",
-				"micromark-extension-gfm-tagfilter": "^2.0.0",
-				"micromark-extension-gfm-task-list-item": "^2.0.0",
-				"micromark-util-combine-extensions": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/micromark-extension-gfm-autolink-literal": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
-			"integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-sanitize-uri": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/micromark-extension-gfm-footnote": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
-			"integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-			"license": "MIT",
-			"dependencies": {
-				"devlop": "^1.0.0",
-				"micromark-core-commonmark": "^2.0.0",
-				"micromark-factory-space": "^2.0.0",
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-normalize-identifier": "^2.0.0",
-				"micromark-util-sanitize-uri": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/micromark-extension-gfm-strikethrough": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
-			"integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
-			"license": "MIT",
-			"dependencies": {
-				"devlop": "^1.0.0",
-				"micromark-util-chunked": "^2.0.0",
-				"micromark-util-classify-character": "^2.0.0",
-				"micromark-util-resolve-all": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/micromark-extension-gfm-table": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
-			"integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
-			"license": "MIT",
-			"dependencies": {
-				"devlop": "^1.0.0",
-				"micromark-factory-space": "^2.0.0",
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/micromark-extension-gfm-tagfilter": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
-			"integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-types": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/micromark-extension-gfm-task-list-item": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
-			"integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
-			"license": "MIT",
-			"dependencies": {
-				"devlop": "^1.0.0",
-				"micromark-factory-space": "^2.0.0",
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/micromark-factory-destination": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
-			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-factory-label": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
-			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"devlop": "^1.0.0",
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-factory-space": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
-			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-factory-title": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
-			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-factory-space": "^2.0.0",
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-factory-whitespace": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
-			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-factory-space": "^2.0.0",
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-character": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
-			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-chunked": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
-			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-symbol": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-classify-character": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
-			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-combine-extensions": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
-			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-chunked": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-decode-numeric-character-reference": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
-			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-symbol": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-decode-string": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
-			"integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"decode-named-character-reference": "^1.0.0",
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-decode-numeric-character-reference": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-encode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
-			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/micromark-util-html-tag-name": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
-			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/micromark-util-normalize-identifier": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
-			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-symbol": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-resolve-all": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
-			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-sanitize-uri": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
-			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-encode": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-subtokenize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
-			"integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"devlop": "^1.0.0",
-				"micromark-util-chunked": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-symbol": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
-			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/micromark-util-types": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
-			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -19333,6 +16775,7 @@
 			"version": "2.30.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
 			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -19342,6 +16785,7 @@
 			"version": "0.5.48",
 			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
 			"integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"moment": "^2.29.4"
@@ -19371,6 +16815,7 @@
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
 			"integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
+			"dev": true,
 			"license": "Apache-2.0 WITH LLVM-exception"
 		},
 		"node_modules/mrmime": {
@@ -19387,6 +16832,7 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/multicast-dns": {
@@ -19407,7 +16853,7 @@
 			"version": "3.3.11",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
 			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -19566,7 +17012,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -19711,6 +17157,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -20083,7 +17530,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"callsites": "^3.0.0"
@@ -20098,36 +17545,11 @@
 			"integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
 			"dev": true
 		},
-		"node_modules/parse-entities": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
-			"integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"character-entities-legacy": "^3.0.0",
-				"character-reference-invalid": "^2.0.0",
-				"decode-named-character-reference": "^1.0.0",
-				"is-alphanumerical": "^2.0.0",
-				"is-decimal": "^2.0.0",
-				"is-hexadecimal": "^2.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/parse-entities/node_modules/@types/unist": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-			"license": "MIT"
-		},
 		"node_modules/parse-json": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
 			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
@@ -20256,7 +17678,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -20307,14 +17729,14 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
 			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -20527,7 +17949,7 @@
 			"version": "8.5.8",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
 			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -21126,14 +18548,14 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
 			"integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/postcss-safe-parser": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
 			"integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -21234,7 +18656,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/postgres-array": {
@@ -21383,6 +18805,7 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.4.0",
@@ -21394,17 +18817,8 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/property-information": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
-			"integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
 		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
@@ -21534,7 +18948,7 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/qified/-/qified-0.9.0.tgz",
 			"integrity": "sha512-4q61YgkHbY6gmwkqm0BsxyLDO3UYdrdiJTJ7JiaZb3xpW1duxn135SB7KqUEkCiuu5O4W+TtwEWP2VjmSRanvA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hookified": "^2.1.0"
@@ -21547,7 +18961,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/hookified/-/hookified-2.1.0.tgz",
 			"integrity": "sha512-ootKng4eaxNxa7rx6FJv2YKef3DuhqbEj3l70oGXwddPQEEnISm50TEZQclqiLTAtilT2nu7TErtCO523hHkyg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/qs": {
@@ -21570,7 +18984,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -21727,49 +19141,12 @@
 				"react": "^18.3.1"
 			}
 		},
-		"node_modules/react-google-charts": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-5.2.1.tgz",
-			"integrity": "sha512-mCbPiObP8yWM5A9ogej7Qp3/HX4EzOwuEzUYvcfHtL98Xt4V/brD14KgfDzSNNtyD48MNXCpq5oVaYKt0ykQUQ==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": ">=16.3.0",
-				"react-dom": ">=16.3.0"
-			}
-		},
 		"node_modules/react-is": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/react-markdown": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
-			"integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"@types/mdast": "^4.0.0",
-				"devlop": "^1.0.0",
-				"hast-util-to-jsx-runtime": "^2.0.0",
-				"html-url-attributes": "^3.0.0",
-				"mdast-util-to-hast": "^13.0.0",
-				"remark-parse": "^11.0.0",
-				"remark-rehype": "^11.0.0",
-				"unified": "^11.0.0",
-				"unist-util-visit": "^5.0.0",
-				"vfile": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			},
-			"peerDependencies": {
-				"@types/react": ">=18",
-				"react": ">=18"
-			}
 		},
 		"node_modules/react-refresh": {
 			"version": "0.14.2",
@@ -21779,107 +19156,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/react-remove-scroll": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-			"integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
-			"license": "MIT",
-			"dependencies": {
-				"react-remove-scroll-bar": "^2.3.7",
-				"react-style-singleton": "^2.2.3",
-				"tslib": "^2.1.0",
-				"use-callback-ref": "^1.3.3",
-				"use-sidecar": "^1.1.3"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/react-remove-scroll-bar": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-			"integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-			"license": "MIT",
-			"dependencies": {
-				"react-style-singleton": "^2.2.2",
-				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/react-style-singleton": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-			"integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-			"license": "MIT",
-			"dependencies": {
-				"get-nonce": "^1.0.0",
-				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/react-textarea-autosize": {
-			"version": "8.5.9",
-			"resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
-			"integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.20.13",
-				"use-composed-ref": "^1.3.0",
-				"use-latest": "^1.2.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
-		"node_modules/react-use-measure": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
-			"integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": ">=16.13",
-				"react-dom": ">=16.13"
-			},
-			"peerDependenciesMeta": {
-				"react-dom": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/read-cache": {
@@ -22032,32 +19308,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/reduce-css-calc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-			"integrity": "sha512-0dVfwYVOlf/LBA2ec4OwQ6p3X9mYxn/wOl2xTcLwjnPYrkgEfPx3VI4eGCH3rQLlPISG5v9I9bkZosKsNRTRKA==",
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^0.4.2",
-				"math-expression-evaluator": "^1.2.14",
-				"reduce-function-call": "^1.0.1"
-			}
-		},
-		"node_modules/reduce-css-calc/node_modules/balanced-match": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-			"integrity": "sha512-STw03mQKnGUYtoNjmowo4F2cRmIIxYEGiMsjjwla/u5P1lxadj/05WkNaFjNiKTgJkj8KiXbgAiRTmcQRwQNtg==",
-			"license": "MIT"
-		},
-		"node_modules/reduce-function-call": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.3.tgz",
-			"integrity": "sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==",
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
 		"node_modules/redux": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -22167,72 +19417,6 @@
 				"regjsparser": "bin/parser"
 			}
 		},
-		"node_modules/remark-gfm": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
-			"integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"mdast-util-gfm": "^3.0.0",
-				"micromark-extension-gfm": "^3.0.0",
-				"remark-parse": "^11.0.0",
-				"remark-stringify": "^11.0.0",
-				"unified": "^11.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-parse": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
-			"integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"micromark-util-types": "^2.0.0",
-				"unified": "^11.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-rehype": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
-			"integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"@types/mdast": "^4.0.0",
-				"mdast-util-to-hast": "^13.0.0",
-				"unified": "^11.0.0",
-				"vfile": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-stringify": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
-			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"mdast-util-to-markdown": "^2.0.0",
-				"unified": "^11.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/rememo": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
@@ -22251,6 +19435,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
 			"integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/require-directory": {
@@ -22267,7 +19452,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -22310,12 +19495,6 @@
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/reselect": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
-			"integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
 			"license": "MIT"
 		},
 		"node_modules/resolve": {
@@ -22380,7 +19559,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -22420,7 +19599,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
 			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"iojs": ">=1.0.0",
@@ -22453,12 +19632,6 @@
 			"engines": {
 				"node": ">=10.0.0"
 			}
-		},
-		"node_modules/robust-predicates": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
-			"integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
-			"license": "Unlicense"
 		},
 		"node_modules/rrweb-cssom": {
 			"version": "0.8.0",
@@ -22516,7 +19689,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -23485,7 +20658,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -23495,7 +20668,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
 			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -23596,7 +20769,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -23643,16 +20816,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/space-separated-tokens": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-			"integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/spawnd": {
@@ -23887,7 +21050,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -23902,7 +21065,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/string.prototype.includes": {
@@ -24018,25 +21181,11 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/stringify-entities": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-			"integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-			"license": "MIT",
-			"dependencies": {
-				"character-entities-html4": "^2.0.0",
-				"character-entities-legacy": "^3.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -24138,24 +21287,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/style-to-js": {
-			"version": "1.1.21",
-			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
-			"integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
-			"license": "MIT",
-			"dependencies": {
-				"style-to-object": "1.0.14"
-			}
-		},
-		"node_modules/style-to-object": {
-			"version": "1.0.14",
-			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
-			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
-			"license": "MIT",
-			"dependencies": {
-				"inline-style-parser": "0.2.7"
-			}
-		},
 		"node_modules/stylehacks": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.1.1.tgz",
@@ -24177,7 +21308,7 @@
 			"version": "16.26.1",
 			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
 			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -24325,7 +21456,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
 			"integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -24349,7 +21480,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
 			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -24372,21 +21503,21 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Python-2.0"
 		},
 		"node_modules/stylelint/node_modules/balanced-match": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
 			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/stylelint/node_modules/cosmiconfig": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
 			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.1",
@@ -24413,7 +21544,7 @@
 			"version": "11.1.2",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
 			"integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"flat-cache": "^6.1.20"
@@ -24423,7 +21554,7 @@
 			"version": "6.1.21",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.21.tgz",
 			"integrity": "sha512-2u7cJfSf7Th7NxEk/VzQjnPoglok2YCsevS7TSbJjcDQWJPbqUUnSYtriHSvtnq+fRZHy1s0ugk4ApnQyhPGoQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cacheable": "^2.3.3",
@@ -24435,7 +21566,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
 			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"global-prefix": "^3.0.0"
@@ -24448,7 +21579,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
 			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ini": "^1.3.5",
@@ -24463,7 +21594,7 @@
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
 			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -24473,7 +21604,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
 			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -24486,7 +21617,7 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -24496,7 +21627,7 @@
 			"version": "13.2.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
 			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -24509,7 +21640,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -24523,7 +21654,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -24536,7 +21667,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -24549,7 +21680,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
 			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
@@ -24570,7 +21701,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -24583,7 +21714,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
 			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0",
@@ -24620,7 +21751,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
 			"integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
-			"devOptional": true
+			"dev": true
 		},
 		"node_modules/svgo": {
 			"version": "3.3.3",
@@ -24706,7 +21837,7 @@
 			"version": "6.9.0",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
 			"integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"ajv": "^8.0.1",
@@ -24723,7 +21854,7 @@
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -24740,7 +21871,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tannin": {
@@ -25119,7 +22250,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -25184,16 +22315,6 @@
 				"tree-kill": "cli.js"
 			}
 		},
-		"node_modules/trim-lines": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-			"integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/trim-newlines": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -25225,16 +22346,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/trough": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
-			"integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -25454,7 +22565,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -25550,105 +22661,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/unified": {
-			"version": "11.0.5",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
-			"integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0",
-				"bail": "^2.0.0",
-				"devlop": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-plain-obj": "^4.0.0",
-				"trough": "^2.0.0",
-				"vfile": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unified/node_modules/is-plain-obj": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/unist-util-is": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
-			"integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-position": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
-			"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-stringify-position": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-visit": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0",
-				"unist-util-is": "^6.0.0",
-				"unist-util-visit-parents": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-visit-parents": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
-			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0",
-				"unist-util-is": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/unpipe": {
@@ -25802,119 +22814,21 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/use-callback-ref": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-			"integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/use-composed-ref": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
-			"integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/use-debounce": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.1.tgz",
-			"integrity": "sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"peerDependencies": {
-				"react": "*"
-			}
-		},
-		"node_modules/use-isomorphic-layout-effect": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
-			"integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/use-latest": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
-			"integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
-			"license": "MIT",
-			"dependencies": {
-				"use-isomorphic-layout-effect": "^1.1.1"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/use-memo-one": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
 			"integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-			}
-		},
-		"node_modules/use-sidecar": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-			"integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-			"license": "MIT",
-			"dependencies": {
-				"detect-node-es": "^1.1.0",
-				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/use-sync-external-store": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
 			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -25924,7 +22838,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/utils-merge": {
@@ -26013,34 +22927,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/vfile": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0",
-				"vfile-message": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/vfile-message": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
-			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0",
-				"unist-util-stringify-position": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/w3c-xmlserializer": {
@@ -26897,16 +23783,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zwitch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "0.1.68",
-		"@automattic/agenttic-ui": "0.1.68",
+		"@automattic/agenttic-client": "file:../agenttic/packages/agenttic-client",
+		"@automattic/agenttic-ui": "file:../agenttic/packages/agenttic-ui",
 		"@wordpress/element": "^6.46.0",
 		"@wordpress/i18n": "^6.21.0"
 	},

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -1684,39 +1684,40 @@ export default function AgentChat( {
 			createElement(
 				'div',
 				{ className: 'frontend-agent-chat__header' },
-				createElement(
-					'div',
-					{ className: 'frontend-agent-chat__agent' },
-					agents.length > 1
-						? createElement(
-								'select',
-								{
-									className:
-										'frontend-agent-chat__agent-select',
-									value: activeAgentSlug,
-									onChange: switchAgent,
-									'aria-label': __(
-										'Select chat agent',
-										'frontend-agent-chat'
-									),
-								},
-								agents.map( ( agent ) =>
-									createElement(
-										'option',
-										{
-											key: agent.slug,
-											value: agent.slug,
-										},
-										agent.name
+				! isInline &&
+					createElement(
+						'div',
+						{ className: 'frontend-agent-chat__agent' },
+						agents.length > 1
+							? createElement(
+									'select',
+									{
+										className:
+											'frontend-agent-chat__agent-select',
+										value: activeAgentSlug,
+										onChange: switchAgent,
+										'aria-label': __(
+											'Select chat agent',
+											'frontend-agent-chat'
+										),
+									},
+									agents.map( ( agent ) =>
+										createElement(
+											'option',
+											{
+												key: agent.slug,
+												value: agent.slug,
+											},
+											agent.name
+										)
 									)
-								)
-						  )
-						: createElement(
-								'span',
-								{ className: 'frontend-agent-chat__title' },
-								activeAgentName
-						  )
-				),
+							  )
+							: createElement(
+									'span',
+									{ className: 'frontend-agent-chat__title' },
+									activeAgentName
+							  )
+					),
 				createElement(
 					'div',
 					{ className: 'frontend-agent-chat__header-actions' },

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -393,6 +393,63 @@
 	border-radius: 0;
 }
 
+.frontend-agent-chat__body .agenttic-embedded {
+	--color-background: var(--frontend-agent-chat-drawer-bg, #f8fafc);
+	--color-foreground: var(--frontend-agent-chat-text-primary, #1e293b);
+	--color-primary: var(--frontend-agent-chat-accent, #2563eb);
+	--color-primary-foreground: #fff;
+	--color-muted: var(--frontend-agent-chat-muted-bg, #e2e8f0);
+	--color-muted-foreground: var(--frontend-agent-chat-text-muted, #64748b);
+	--color-popover: var(--frontend-agent-chat-drawer-bg, #f8fafc);
+	--color-popover-muted: var(--frontend-agent-chat-bg-muted, #f8fafc);
+	--color-ring: var(--frontend-agent-chat-accent, #2563eb);
+	background: var(--color-background);
+	color: var(--color-foreground);
+	font-family: var(--frontend-agent-chat-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+	height: 100%;
+	min-height: 0;
+}
+
+.frontend-agent-chat__body .agenttic-embedded__messages,
+.frontend-agent-chat__body .agenttic-embedded__footer {
+	background: var(--color-background);
+}
+
+.frontend-agent-chat__body .agenttic-embedded__footer {
+	border-top-color: var(--frontend-agent-chat-border-color, #e2e8f0);
+}
+
+.frontend-agent-chat__body .agenttic-embedded__message p {
+	background: var(--frontend-agent-chat-message-bg, #fff);
+	color: var(--color-foreground);
+}
+
+.frontend-agent-chat__body .agenttic-embedded__message--user p {
+	background: var(--frontend-agent-chat-accent, #2563eb);
+	color: #fff;
+}
+
+.frontend-agent-chat__body .agenttic-embedded__thinking,
+.frontend-agent-chat__body .agenttic-embedded__error,
+.frontend-agent-chat__body .agenttic-embedded__empty,
+.frontend-agent-chat__body .agenttic-embedded__notice {
+	color: var(--frontend-agent-chat-text-muted, #64748b);
+}
+
+.frontend-agent-chat__body .agenttic-embedded__suggestions button,
+.frontend-agent-chat__body .agenttic-embedded__input button,
+.frontend-agent-chat__body .agenttic-embedded__input textarea {
+	border-color: var(--frontend-agent-chat-border-color, #e2e8f0);
+	background: var(--frontend-agent-chat-input-bg, #fff);
+	color: var(--color-foreground);
+}
+
+.frontend-agent-chat__body .agenttic-embedded__input textarea:focus {
+	border-color: var(--frontend-agent-chat-accent, #2563eb);
+	outline: 2px solid var(--frontend-agent-chat-accent, #2563eb);
+	outline-offset: 2px;
+}
+
 .frontend-agent-chat__body .ec-chat-messages,
 .frontend-agent-chat__body .ec-chat-input-area,
 .frontend-agent-chat__body .ec-chat-session-switcher,

--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -410,9 +410,26 @@
 	min-height: 0;
 }
 
+.frontend-agent-chat__body .agenttic-embedded__conversation {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+}
+
 .frontend-agent-chat__body .agenttic-embedded__messages,
 .frontend-agent-chat__body .agenttic-embedded__footer {
 	background: var(--color-background);
+}
+
+.frontend-agent-chat__body .agenttic-embedded__messages {
+	flex: 1 1 auto;
+	min-height: 0;
+}
+
+.frontend-agent-chat__body .agenttic-embedded__footer {
+	flex: 0 0 auto;
 }
 
 .frontend-agent-chat__body .agenttic-embedded__footer {


### PR DESCRIPTION
## Summary
- Pin Frontend Agent Chat to the local Agenttic workspace packages so local iteration uses Agenttic trunk/HEAD instead of the stale published 0.1.68 packages.
- Restore inline mode so the agent title remains in the in-chat empty state rather than the drawer chrome.
- Add CSS bridge rules for the current Agenttic embedded DOM, including dark theme variables and inline height constraints.

## Context
Agenttic trunk contains fixes merged after the 0.1.68 npm package release, including embedded chat message handling, Agents API chat state/question normalization, and generic question-card primitives. This PR intentionally pins to the local Agenttic workspace for current development/deploy iteration.

## Testing
- npm run typecheck
- npm run build
- Deployed to studio-native-runtime with Homeboy from this branch HEAD
- Flushed remote WordPress object cache

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Regression tracing across FAC/Agenttic/Studio Native branches, local Agenttic pin setup, and CSS/layout fix drafting.