### PR TITLE
Add configurable chat header controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ update_option( 'frontend_agent_chat_config', [
     'enabled'     => true,
     'fab_label'   => 'Agent Chat',
     'fab_icon'    => 'AI',
+    'header_controls' => [
+        'agent_selector'    => true,
+        'session_controls' => true,
+        'expand_button'    => true,
+        'close_button'     => true,
+    ],
 ] );
 ```
 
@@ -33,6 +39,10 @@ update_option( 'frontend_agent_chat_config', [
 | `enabled` | `bool` | Toggle the chat on/off for this site |
 | `fab_label` | `string` | Floating action button label |
 | `fab_icon` | `string` | Floating action button icon or short text |
+| `header_controls.agent_selector` | `bool` | Show the agent selector/title in the drawer header |
+| `header_controls.session_controls` | `bool` | Show new/session picker controls in the drawer header |
+| `header_controls.expand_button` | `bool` | Show the viewport expand/collapse button |
+| `header_controls.close_button` | `bool` | Show the drawer close button |
 
 The config can also be overridden via the `frontend_agent_chat_config` filter.
 

--- a/inc/config.php
+++ b/inc/config.php
@@ -30,6 +30,12 @@ function frontend_agent_chat_get_config(): array {
 		'message_suggestions'  => array(),
 		'chat_context'         => array(),
 		'operator_diagnostics' => false,
+		'header_controls'      => array(
+			'agent_selector'    => true,
+			'session_controls' => true,
+			'expand_button'    => true,
+			'close_button'     => true,
+		),
 		'layout'               => 'floating',
 	);
 

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -135,6 +135,34 @@ function frontend_agent_chat_sanitize_chat_context( $context ): array {
 }
 
 /**
+ * Sanitize header control visibility configuration.
+ *
+ * @param mixed $controls Raw header controls configuration.
+ * @return array{agentSelector:bool,sessionControls:bool,expandButton:bool,closeButton:bool} Sanitized controls.
+ */
+function frontend_agent_chat_sanitize_header_controls( $controls ): array {
+	$defaults = array(
+		'agent_selector'    => true,
+		'session_controls' => true,
+		'expand_button'    => true,
+		'close_button'     => true,
+	);
+
+	if ( ! is_array( $controls ) ) {
+		$controls = array();
+	}
+
+	$controls = wp_parse_args( $controls, $defaults );
+
+	return array(
+		'agentSelector'    => (bool) $controls['agent_selector'],
+		'sessionControls' => (bool) $controls['session_controls'],
+		'expandButton'    => (bool) $controls['expand_button'],
+		'closeButton'     => (bool) $controls['close_button'],
+	);
+}
+
+/**
  * Enqueue the frontend chat script and styles.
  *
  * Fires on wp_enqueue_scripts so the assets load on every frontend page.
@@ -206,6 +234,7 @@ function frontend_agent_chat_enqueue() {
 		'collapseIconPath'           => frontend_agent_chat_sanitize_svg_path( $config['collapse_icon_path'] ?? '' ),
 		'expandIconViewBox'          => frontend_agent_chat_sanitize_svg_view_box( $config['expand_icon_view_box'] ?? '0 0 24 24' ),
 		'layout'                     => 'inline' === ( $config['layout'] ?? '' ) ? 'inline' : 'floating',
+		'headerControls'             => frontend_agent_chat_sanitize_header_controls( $config['header_controls'] ?? array() ),
 		'isLoggedIn'                 => is_user_logged_in(),
 		'canUploadFiles'             => is_user_logged_in() && current_user_can( 'upload_files' ),
 		'capabilities'               => $capabilities,

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -80,6 +80,12 @@ interface AgentChatProps {
 	collapseIconPath?: string;
 	expandIconViewBox?: string;
 	layout?: 'floating' | 'inline';
+	headerControls?: {
+		agentSelector?: boolean;
+		sessionControls?: boolean;
+		expandButton?: boolean;
+		closeButton?: boolean;
+	};
 	isLoggedIn?: boolean;
 	loadingMessages?:
 		| boolean
@@ -1138,6 +1144,7 @@ export default function AgentChat( {
 	collapseIconPath,
 	expandIconViewBox = '0 0 24 24',
 	layout = 'floating',
+	headerControls,
 	isLoggedIn = false,
 	loadingMessages = true,
 	persistenceCta,
@@ -1632,7 +1639,13 @@ export default function AgentChat( {
 				'frontend-agent-chat'
 		  )
 		: persistenceCta?.message;
-	const showSessionControls = chatStorageReady && activeAgentSlug;
+	const showAgentSelector = headerControls?.agentSelector !== false;
+	const showSessionControls =
+		headerControls?.sessionControls !== false &&
+		chatStorageReady &&
+		!! activeAgentSlug;
+	const showExpandButton = headerControls?.expandButton !== false;
+	const showCloseButton = headerControls?.closeButton !== false;
 	const expandedButtonLabel = isExpanded
 		? __( 'Exit expanded chat view', 'frontend-agent-chat' )
 		: __( 'Expand chat to viewport', 'frontend-agent-chat' );
@@ -1685,6 +1698,7 @@ export default function AgentChat( {
 				'div',
 				{ className: 'frontend-agent-chat__header' },
 				! isInline &&
+					showAgentSelector &&
 					createElement(
 						'div',
 						{ className: 'frontend-agent-chat__agent' },
@@ -1783,30 +1797,32 @@ export default function AgentChat( {
 									)
 								)
 						),
-					createElement(
-						'button',
-						{
-							type: 'button',
-							className: 'frontend-agent-chat__expand',
-							onClick: toggleExpanded,
-							'aria-label': expandedButtonLabel,
-							'aria-pressed': isExpanded,
-						},
-						renderExpandIcon(
-							expandButtonIconPath,
-							expandIconViewBox
+					showExpandButton &&
+						createElement(
+							'button',
+							{
+								type: 'button',
+								className: 'frontend-agent-chat__expand',
+								onClick: toggleExpanded,
+								'aria-label': expandedButtonLabel,
+								'aria-pressed': isExpanded,
+							},
+							renderExpandIcon(
+								expandButtonIconPath,
+								expandIconViewBox
+							)
+						),
+					showCloseButton &&
+						createElement(
+							'button',
+							{
+								type: 'button',
+								className: 'frontend-agent-chat__close',
+								onClick: close,
+								'aria-label': __( 'Close', 'frontend-agent-chat' ),
+							},
+							'\u00D7'
 						)
-					),
-					createElement(
-						'button',
-						{
-							type: 'button',
-							className: 'frontend-agent-chat__close',
-							onClick: close,
-							'aria-label': __( 'Close', 'frontend-agent-chat' ),
-						},
-						'\u00D7'
-					)
 				)
 			),
 			createElement(

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,12 @@ declare global {
 			collapseIconPath?: string;
 			expandIconViewBox?: string;
 			layout?: 'floating' | 'inline';
+			headerControls?: {
+				agentSelector?: boolean;
+				sessionControls?: boolean;
+				expandButton?: boolean;
+				closeButton?: boolean;
+			};
 			isLoggedIn?: boolean;
 			loadingMessages?: boolean | {
 				mode?: 'default' | 'extend' | 'override';
@@ -111,6 +117,7 @@ function init(): void {
 			collapseIconPath: config.collapseIconPath,
 			expandIconViewBox: config.expandIconViewBox,
 			layout: config.layout,
+			headerControls: config.headerControls,
 			isLoggedIn: config.isLoggedIn ?? false,
 			loadingMessages: config.loadingMessages ?? true,
 			persistenceCta: config.persistenceCta,

--- a/tests/header-controls-config-smoke.php
+++ b/tests/header-controls-config-smoke.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Smoke tests for frontend chat header controls config sanitation.
+ *
+ * @package FrontendAgentChat\Tests
+ */
+
+function frontend_agent_chat_header_controls_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_parse_args' ) ) {
+	function wp_parse_args( $args, $defaults = array() ) {
+		return array_merge( $defaults, is_array( $args ) ? $args : array() );
+	}
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/enqueue.php';
+
+$defaults = frontend_agent_chat_sanitize_header_controls( null );
+frontend_agent_chat_header_controls_assert( true === $defaults['agentSelector'], 'Agent selector defaults on.' );
+frontend_agent_chat_header_controls_assert( true === $defaults['sessionControls'], 'Session controls default on.' );
+frontend_agent_chat_header_controls_assert( true === $defaults['expandButton'], 'Expand button defaults on.' );
+frontend_agent_chat_header_controls_assert( true === $defaults['closeButton'], 'Close button defaults on.' );
+
+$controls = frontend_agent_chat_sanitize_header_controls(
+	array(
+		'agent_selector'    => false,
+		'session_controls' => false,
+		'expand_button'    => false,
+		'close_button'     => false,
+	)
+);
+
+frontend_agent_chat_header_controls_assert( false === $controls['agentSelector'], 'Agent selector can be disabled.' );
+frontend_agent_chat_header_controls_assert( false === $controls['sessionControls'], 'Session controls can be disabled.' );
+frontend_agent_chat_header_controls_assert( false === $controls['expandButton'], 'Expand button can be disabled.' );
+frontend_agent_chat_header_controls_assert( false === $controls['closeButton'], 'Close button can be disabled.' );
+
+echo "Frontend header-controls config smoke passed (8 assertions).\n";


### PR DESCRIPTION
## Summary
- Add generic frontend-agent-chat header control config for agent selector, session controls, expand, and close buttons.
- Localize the config to the React app and gate wrapper header controls from FAC.
- Document the config and add a PHP smoke test for defaults and disabled controls.

## Testing
- php tests/header-controls-config-smoke.php
- for f in tests/*-smoke.php; do php ""; done
- npm run typecheck
- npm run test:unit
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Tracing FAC/Agenttic/Studio Native boundaries, implementing the configurable FAC controls, adding smoke coverage, and running verification.