### PR TITLE
Theme embedded markdown bubbles

### DIFF
--- a/src/agent-chat.css
+++ b/src/agent-chat.css
@@ -436,14 +436,21 @@
 	border-top-color: var(--frontend-agent-chat-border-color, #e2e8f0);
 }
 
-.frontend-agent-chat__body .agenttic-embedded__message p {
+.frontend-agent-chat__body .agenttic-embedded__bubble {
 	background: var(--frontend-agent-chat-message-bg, #fff);
 	color: var(--color-foreground);
 }
 
-.frontend-agent-chat__body .agenttic-embedded__message--user p {
+.frontend-agent-chat__body .agenttic-embedded__message--user .agenttic-embedded__bubble {
 	background: var(--frontend-agent-chat-accent, #2563eb);
 	color: #fff;
+}
+
+.frontend-agent-chat__body .agenttic-embedded__bubble a,
+.frontend-agent-chat__body .agenttic-embedded__bubble strong,
+.frontend-agent-chat__body .agenttic-embedded__bubble code,
+.frontend-agent-chat__body .agenttic-embedded__bubble li::marker {
+	color: inherit;
 }
 
 .frontend-agent-chat__body .agenttic-embedded__thinking,


### PR DESCRIPTION
## Summary
- Update frontend-agent-chat's Agenttic embedded UI theme override to style the bubble wrapper instead of individual paragraphs.
- Keep links, strong text, code, and list markers inheriting the bubble foreground color.
- Supports Agenttic embedded markdown bubbles that contain paragraphs, lists, and other block content.

## Testing
- npm run typecheck
- npm run test:unit
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Tracing the embedded Agenttic/FAC markdown styling issue, updating the FAC theme override, and running targeted verification.