### PR TITLE
Persist chat session titles

### DIFF
--- a/inc/rest.php
+++ b/inc/rest.php
@@ -144,6 +144,16 @@ function frontend_agent_chat_register_rest_routes(): void {
 
 	register_rest_route(
 		'frontend-agent-chat/v1',
+		'/chat/(?P<session_id>[^/]+)/title',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'frontend_agent_chat_rest_update_session_title',
+			'permission_callback' => 'frontend_agent_chat_rest_can_chat',
+		)
+	);
+
+	register_rest_route(
+		'frontend-agent-chat/v1',
 		'/chat/(?P<session_id>[^/]+)',
 		array(
 			array(
@@ -845,6 +855,53 @@ function frontend_agent_chat_rest_mark_session_read( WP_REST_Request $request ):
 }
 
 /**
+ * Update a stored session title through Agents API.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function frontend_agent_chat_rest_update_session_title( WP_REST_Request $request ) {
+	$config     = frontend_agent_chat_get_config();
+	$agent_slug = frontend_agent_chat_rest_get_agent_slug( $request, frontend_agent_chat_get_default_agent_slug( $config ) );
+	$session_id = sanitize_text_field( (string) $request['session_id'] );
+	$title      = trim( sanitize_text_field( (string) $request->get_param( 'title' ) ) );
+
+	if ( '' === $agent_slug || '' === $session_id ) {
+		return new WP_Error( 'frontend_agent_chat_invalid_session_title_request', __( 'agent and session_id are required.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+	}
+
+	if ( '' === $title ) {
+		return new WP_Error( 'frontend_agent_chat_empty_session_title', __( 'Session title cannot be empty.', 'frontend-agent-chat' ), array( 'status' => 400 ) );
+	}
+
+	$result = frontend_agent_chat_execute_ability(
+		'agents/update-conversation-session-title',
+		frontend_agent_chat_add_browser_principal_input(
+			array(
+				'agent'      => $agent_slug,
+				'session_id' => $session_id,
+				'title'      => $title,
+			)
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	$session = is_array( $result['session'] ?? null ) ? $result['session'] : array();
+	return rest_ensure_response(
+		array(
+			'success' => true,
+			'data'    => array(
+				'session_id' => frontend_agent_chat_extract_session_id( $session ) ?: $session_id,
+				'title'      => (string) ( $session['title'] ?? $title ),
+			),
+		)
+	);
+}
+
+/**
  * Normalize canonical chat run-control ability output for REST clients.
  *
  * @param array  $result     Ability result.
@@ -1281,16 +1338,21 @@ function frontend_agent_chat_flatten_message_content( $content ): string {
  * @return array
  */
 function frontend_agent_chat_session_summary( array $session ): array {
-	$messages = frontend_agent_chat_session_messages( $session );
+	$messages      = frontend_agent_chat_session_messages( $session );
+	$stored_title  = trim( (string) ( $session['title'] ?? '' ) );
+	$metadata      = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
+	$metadata['has_stored_title'] = '' !== $stored_title;
+	$metadata['stored_title']     = $stored_title;
 	return array(
 		'session_id'    => frontend_agent_chat_extract_session_id( $session ),
-		'title'         => (string) ( $session['title'] ?? frontend_agent_chat_title_from_messages( $messages ) ),
+		'title'         => '' !== $stored_title ? $stored_title : frontend_agent_chat_title_from_messages( $messages ),
 		'context'       => (string) ( $session['context'] ?? 'frontend-agent-chat' ),
 		'first_message' => frontend_agent_chat_first_user_message( $messages ),
 		'message_count' => count( $messages ),
 		'unread_count'  => (int) ( $session['unread_count'] ?? 0 ),
 		'created_at'    => (string) ( $session['created_at'] ?? '' ),
 		'updated_at'    => (string) ( $session['updated_at'] ?? '' ),
+		'metadata'      => $metadata,
 	);
 }
 

--- a/src/AgentChat.tsx
+++ b/src/AgentChat.tsx
@@ -32,6 +32,7 @@ import type {
 	AgentsApiRunAdapter as ChatRunAdapter,
 	AgentsApiRunCapabilities as ChatRunCapabilities,
 	AgentsApiRunEvent as ChatRunEvent,
+	AgentsApiSession,
 	AgentsApiToolRenderers,
 	AgentsApiToolGroup,
 } from '@automattic/agenttic-client/agents-api';
@@ -51,6 +52,7 @@ import {
 	useCallback,
 	useMemo,
 	useEffect,
+	useRef,
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
@@ -669,6 +671,69 @@ function getSessionLabel(
 		/* translators: %d: chat session number. */
 		__( 'Chat %d', 'frontend-agent-chat' ),
 		index + 1
+	);
+}
+
+function getMostRecentSession(
+	sessions: AgentsApiSession[]
+): AgentsApiSession | undefined {
+	return sessions.reduce< AgentsApiSession | undefined >( ( latest, session ) => {
+		if ( ! latest ) {
+			return session;
+		}
+
+		const latestTime = Date.parse(
+			latest.updatedAt ||
+				latest.updated_at ||
+				latest.createdAt ||
+				latest.created_at ||
+				''
+		);
+		const sessionTime = Date.parse(
+			session.updatedAt ||
+				session.updated_at ||
+				session.createdAt ||
+				session.created_at ||
+				''
+		);
+		if ( Number.isNaN( sessionTime ) ) {
+			return latest;
+		}
+
+		return Number.isNaN( latestTime ) || sessionTime > latestTime
+			? session
+			: latest;
+	}, undefined );
+}
+
+function getMessageText( message: AgentsApiMessage ): string {
+	return message.content
+		.filter( ( part ) => part.type === 'text' && typeof part.text === 'string' )
+		.map( ( part ) => part.text )
+		.join( ' ' )
+		.replace( /\s+/g, ' ' )
+		.trim();
+}
+
+function getSessionTitleFromMessages( messages: AgentsApiMessage[] ): string {
+	const firstUserMessage = messages.find( ( message ) => message.role === 'user' );
+	if ( ! firstUserMessage ) {
+		return '';
+	}
+
+	const text = getMessageText( firstUserMessage );
+	return text.length > 60 ? `${ text.slice( 0, 57 ).trimEnd() }...` : text;
+}
+
+function sessionHasStoredTitle( session: AgentsApiSession ): boolean {
+	const metadata = session.metadata ?? {};
+	if ( metadata.has_stored_title === true ) {
+		return true;
+	}
+
+	return (
+		typeof metadata.stored_title === 'string' &&
+		metadata.stored_title.trim() !== ''
 	);
 }
 
@@ -1479,6 +1544,21 @@ export default function AgentChat( {
 		onUnreadChange: setUnreadCount,
 		isVisible: isOpen && !! activeAgentSlug && chatStorageReady,
 	} );
+	const sessionBootstrapRef = useRef< {
+		agentSlug: string;
+		waitingForSessions: AgentsApiSession[] | null;
+		bootstrapped: boolean;
+	} >( {
+		agentSlug: '',
+		waitingForSessions: null,
+		bootstrapped: false,
+	} );
+	const currentSessionsRef = useRef< AgentsApiSession[] >( chat.sessions );
+	const titleUpdateInFlightRef = useRef< Set< string > >( new Set() );
+	const titledSessionIdsRef = useRef< Set< string > >( new Set() );
+	useEffect( () => {
+		currentSessionsRef.current = chat.sessions;
+	}, [ chat.sessions ] );
 	useEffect( () => {
 		if ( ! chat.isProcessing || loadingMessageOptions.length < 2 ) {
 			setLoadingMessageIndex( 0 );
@@ -1626,9 +1706,112 @@ export default function AgentChat( {
 	);
 	const newChatSession = chat.newSession;
 	useEffect( () => {
+		sessionBootstrapRef.current = {
+			agentSlug: activeAgentSlug,
+			waitingForSessions: isLoggedIn ? currentSessionsRef.current : null,
+			bootstrapped: ! isLoggedIn,
+		};
 		newChatSession();
 		setUnreadCount( 0 );
-	}, [ activeAgentSlug, newChatSession ] );
+	}, [ activeAgentSlug, isLoggedIn, newChatSession ] );
+	useEffect( () => {
+		const bootstrap = sessionBootstrapRef.current;
+		if (
+			! isLoggedIn ||
+			! chatStorageReady ||
+			! activeAgentSlug ||
+			bootstrap.agentSlug !== activeAgentSlug ||
+			bootstrap.bootstrapped
+		) {
+			return;
+		}
+
+		if ( chat.sessionId ) {
+			bootstrap.bootstrapped = true;
+			return;
+		}
+
+		if ( bootstrap.waitingForSessions === chat.sessions ) {
+			return;
+		}
+
+		const latestSession = getMostRecentSession( chat.sessions );
+		bootstrap.bootstrapped = true;
+		if ( latestSession?.id ) {
+			chat.loadSession( latestSession.id );
+		}
+	}, [
+		activeAgentSlug,
+		chat.sessions,
+		chat.sessionId,
+		chat.loadSession,
+		chatStorageReady,
+		isLoggedIn,
+	] );
+	useEffect( () => {
+		if (
+			! activeAgentSlug ||
+			! chatStorageReady ||
+			chat.isProcessing ||
+			! chat.sessionId
+		) {
+			return;
+		}
+
+		const sessionId = chat.sessionId;
+		const session = chat.sessions.find( ( item ) => item.id === sessionId );
+		if ( ! session ) {
+			return;
+		}
+
+		if ( sessionHasStoredTitle( session ) ) {
+			titledSessionIdsRef.current.add( sessionId );
+			return;
+		}
+
+		if (
+			titledSessionIdsRef.current.has( sessionId ) ||
+			titleUpdateInFlightRef.current.has( sessionId )
+		) {
+			return;
+		}
+
+		const title = getSessionTitleFromMessages( chat.messages );
+		if ( ! title ) {
+			return;
+		}
+
+		titleUpdateInFlightRef.current.add( sessionId );
+		agentFetch( {
+			path: `${ basePath }/${ encodeURIComponent( sessionId ) }/title`,
+			method: 'POST',
+			data: { title },
+		} )
+			.then( () => {
+				titledSessionIdsRef.current.add( sessionId );
+				return chat.loadSession( sessionId );
+			} )
+			.catch( ( err: unknown ) => {
+				// eslint-disable-next-line no-console
+				console.error(
+					'AgentChat: failed to update session title',
+					err
+				);
+			} )
+			.finally( () => {
+				titleUpdateInFlightRef.current.delete( sessionId );
+			} );
+	}, [
+		activeAgentSlug,
+		agentFetch,
+		basePath,
+		chat.isProcessing,
+		chat.loadSession,
+		chat.messages,
+		chat.sessionId,
+		chat.sessions,
+		chatStorageReady,
+	] );
 	const hasPersistenceCta = !! (
 		persistenceCta?.message ||
 		( persistenceCta?.actionUrl && persistenceCta?.actionLabel )


### PR DESCRIPTION
## Summary
- load the most recent stored session for logged-in return visits instead of always starting a blank chat
- add a Frontend Agent Chat REST wrapper for Agents API session title updates
- persist a deterministic first-message title when a session has no stored title yet

## Testing
- php -l inc/rest.php
- npm run typecheck
- npm run build
- npm run test:diagnostics
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Tracing the FAC/Agents API session-title flow, implementing the session restore and title persistence plumbing, and running verification.